### PR TITLE
Fix reduceRunMatrix to preserve attributes

### DIFF
--- a/R/eval_design.R
+++ b/R/eval_design.R
@@ -86,6 +86,8 @@
 eval_design = function(RunMatrix, model, alpha, blockmodel=NULL, anticoef=NULL,
                        delta=2, varianceratio=1, contrasts="contr.sum", conservative=FALSE) {
 
+  RunMatrix = reduceRunMatrix(RunMatrix,model)
+
   contrastslist = list()
   for(x in names(RunMatrix[sapply(RunMatrix,class) == "factor"])) {
     contrastslist[x] = contrasts
@@ -95,7 +97,6 @@ eval_design = function(RunMatrix, model, alpha, blockmodel=NULL, anticoef=NULL,
   }
   attr(RunMatrix,"modelmatrix") = model.matrix(model,RunMatrix,contrasts.arg=contrastslist)
 
-  RunMatrix = reduceRunMatrix(RunMatrix,model)
 
   if(!is.null(blockmodel)) {
     BlockDesign = data.frame()

--- a/R/eval_design_custom_mc.R
+++ b/R/eval_design_custom_mc.R
@@ -90,8 +90,11 @@ eval_design_custom_mc = function(RunMatrix, model, alpha, nsim, rfunction, fitfu
   blocking = FALSE
 
   #---------- Generating model matrix ----------#
+  #remove columns from variables not used in the model
+  RunMatrixReduced = reduceRunMatrix(RunMatrix,model)
+
   contrastslist = list()
-  for(x in names(RunMatrix[lapply(RunMatrix,class) == "factor"])) {
+  for(x in names(RunMatrixReduced[lapply(RunMatrixReduced,class) == "factor"])) {
     contrastslist[[x]] = contrasts
   }
 
@@ -101,11 +104,9 @@ eval_design_custom_mc = function(RunMatrix, model, alpha, nsim, rfunction, fitfu
 
   #---------- Convert dot formula to terms -----#
   if((as.character(model)[2] == ".")) {
-    model = as.formula(paste("~",paste(attr(RunMatrix,"names"),collapse=" + "),sep=""))
+    model = as.formula(paste("~",paste(attr(RunMatrixReduced,"names"),collapse=" + "),sep=""))
   }
 
-  #remove columns from variables not used in the model
-  RunMatrixReduced = reduceRunMatrix(RunMatrix,model)
   ModelMatrix = model.matrix(model,RunMatrixReduced,contrasts.arg=contrastslist)
 
   # autogenerate anticipated coefficients

--- a/R/eval_design_mc.R
+++ b/R/eval_design_mc.R
@@ -174,8 +174,11 @@ eval_design_mc = function(RunMatrix, model, alpha, nsim, glmfamily, rfunction, a
                           conservative=FALSE, contrasts=contr.simplex, parallel=FALSE) {
 
   #---------- Generating model matrix ----------#
+  #Remove columns from variables not used in the model
+  RunMatrixReduced = reduceRunMatrix(RunMatrix,model)
+
   contrastslist = list()
-  for(x in names(RunMatrix[lapply(RunMatrix,class) == "factor"])) {
+  for(x in names(RunMatrixReduced[lapply(RunMatrixReduced, class) == "factor"])) {
     contrastslist[[x]] = contrasts
   }
   if(length(contrastslist) < 1) {
@@ -184,11 +187,9 @@ eval_design_mc = function(RunMatrix, model, alpha, nsim, glmfamily, rfunction, a
 
   #---------- Convert dot formula to terms -----#
   if((as.character(model)[2] == ".")) {
-    model = as.formula(paste("~",paste(attr(RunMatrix,"names"),collapse=" + "),sep=""))
+    model = as.formula(paste("~", paste(attr(RunMatrixReduced, "names"), collapse=" + "), sep=""))
   }
 
-  #Remove columns from variables not used in the model
-  RunMatrixReduced = reduceRunMatrix(RunMatrix,model)
   ModelMatrix = model.matrix(model,RunMatrixReduced,contrasts.arg=contrastslist)
 
   #-----Autogenerate Anticipated Coefficients---#

--- a/R/eval_design_survival_mc.R
+++ b/R/eval_design_survival_mc.R
@@ -75,8 +75,11 @@ eval_design_survival_mc = function(RunMatrix, model, alpha, nsim, distribution, 
                           conservative=FALSE, parallel=FALSE, ...) {
 
   #---------- Generating model matrix ----------#
+  #remove columns from variables not used in the model
+  RunMatrixReduced = reduceRunMatrix(RunMatrix,model)
+
   contrastslist = list()
-  for(x in names(RunMatrix[lapply(RunMatrix,class) == "factor"])) {
+  for(x in names(RunMatrix[lapply(RunMatrixReduced, class) == "factor"])) {
     contrastslist[[x]] = contrasts
   }
   if(length(contrastslist) < 1) {
@@ -85,11 +88,9 @@ eval_design_survival_mc = function(RunMatrix, model, alpha, nsim, distribution, 
 
   #---------- Convert dot formula to terms -----#
   if((as.character(model)[2] == ".")) {
-    model = as.formula(paste("~",paste(attr(RunMatrix,"names"),collapse=" + "),sep=""))
+    model = as.formula(paste("~", paste(attr(RunMatrixReduced, "names"), collapse=" + "), sep=""))
   }
 
-  #remove columns from variables not used in the model
-  RunMatrixReduced = reduceRunMatrix(RunMatrix,model)
   ModelMatrix = model.matrix(model,RunMatrixReduced,contrasts.arg=contrastslist)
 
   # autogenerate anticipated coefficients

--- a/R/reduceRunMatrix.R
+++ b/R/reduceRunMatrix.R
@@ -4,15 +4,15 @@
 #'
 #'@param ModelMatrix The model matrix
 #'@param model The formula
-#'@return The reduced model matrix
+#'@return The reduced model matrix.
 #'@keywords internal
 reduceRunMatrix = function(RunMatrix,model) {
   ReduceRM = RunMatrix
   if(length(as.character(model)) == 2 && as.character(model)[2] == ".") {
     return(ReduceRM)
   }
-  ats = attributes(ReduceRM)
-  ReduceRM = ReduceRM[colnames(ReduceRM) %in% all.vars(model)]
-  attributes(ReduceRM) = ats
+  for (var in colnames(ReduceRM)) {
+    if (!(var %in% all.vars(model))) ReduceRM[var] = NULL
+  }
   ReduceRM
 }


### PR DESCRIPTION
Previous version failed because it tried to preserve all attributes, including protected ones like 'names'. This version just removes individual columns, like the initial version did before I messed it up.

Move all calls to reduceRunMatrix to beginning of functions.