### PR TITLE
Add blocking to eval_design_mc

### DIFF
--- a/R/generate_block_noise.R
+++ b/R/generate_block_noise.R
@@ -1,0 +1,26 @@
+
+#' Title Generate total noise from blocks in each run
+#'
+#' @param blockindicators Run Matrix indicating which block each run is in. Must be numeric.
+#' @param levels_in_block List of the levels in each block. Each list must be numeric, and the levels
+#' must run from 1 .. nblocks
+#' @param blocknoise Vector of standard deviation of noise in each level, one entry per block
+#'
+#' @return Returns a vector of the total noise in each run, simulated with rnorm.
+#' @export
+#'
+#' @examples
+#' total_block_noise = generate_block_noise(blockindicators, levels_in_block, blocknoise)
+#'
+generate_block_noise <- function(blockindicators, levels_in_block, blocknoise) {
+  #Each block gets a single random draw, and that draw is replicated for each run in the block
+  noise_from_blocks = rep(0, nrow(blockindicators)) #this will hold the total random noise due to blocks in each run
+  if(!is.null(blocknoise)) {
+    #the last column of blockindicators is the run number, not a block indicator
+    for(i in 1:(ncol(blockindicators) - 1)) {
+      blocknoise_realized = rnorm(length(levels_in_block[[i]]), mean = 0, sd = blocknoise[i])
+      noise_from_blocks = noise_from_blocks + blocknoise_realized[blockindicators[, i]]
+    }
+  }
+  noise_from_blocks
+}

--- a/R/generate_block_noise.R
+++ b/R/generate_block_noise.R
@@ -1,16 +1,23 @@
 
 #' Title Generate total noise from blocks in each run
 #'
-#' @param blockindicators Run Matrix indicating which block each run is in. Must be numeric.
-#' @param levels_in_block List of the levels in each block. Each list must be numeric, and the levels
-#' must run from 1 .. nblocks
-#' @param blocknoise Vector of standard deviation of noise in each level, one entry per block
+#' @param blockindicators Run Matrix indicating which block each run is in. The last column is assumed
+#' to be a run number, and is therefore ignored. i.e. the number of columns must be one greater than the
+#' number of blocking layers.
+#' @param levels_in_block List of the levels in each block. The i-th entry in the list must be a vector
+#' of the levels of the i-th block layer.
+#' @param blocknoise Vector of standard deviation of noise in each block, one entry per block layer.
 #'
 #' @return Returns a vector of the total noise in each run, simulated with rnorm.
 #' @export
 #'
 #' @examples
-#' total_block_noise = generate_block_noise(blockindicators, levels_in_block, blocknoise)
+#' library(plyr)
+#'
+#' blockmatrix = cbind(c(1,1,1,1,2,2,2,2), c('a', 'a', 'b', 'b', 'c', 'c', 'd', 'd'), 1:8)
+#' levs = alply(blockmatrix, 2, unique)
+#' noiselevels = c(10, 1)
+#' generate_block_noise(blockmatrix, levs, noiselevels)
 #'
 generate_block_noise <- function(blockindicators, levels_in_block, blocknoise) {
   #Each block gets a single random draw, and that draw is replicated for each run in the block
@@ -19,6 +26,7 @@ generate_block_noise <- function(blockindicators, levels_in_block, blocknoise) {
     #the last column of blockindicators is the run number, not a block indicator
     for(i in 1:(ncol(blockindicators) - 1)) {
       blocknoise_realized = rnorm(length(levels_in_block[[i]]), mean = 0, sd = blocknoise[i])
+      names(blocknoise_realized) = levels_in_block[[i]]
       noise_from_blocks = noise_from_blocks + blocknoise_realized[blockindicators[, i]]
     }
   }

--- a/tests/testthat/testExampleCode.R
+++ b/tests/testthat/testExampleCode.R
@@ -185,8 +185,8 @@ test_that("eval_design_mc example code runs without errors", {
   #'#to create a function that generates random numbers based on our run matrix X and
   #'#our anticipated coefficients (b).
   #'
-  rgen = function(X,b) {
-    return(rnorm(n=nrow(X), mean = X %*% b, sd = 1))
+  rgen = function(X, b, delta) {
+    return(rnorm(n=nrow(X), mean = X %*% b + delta, sd = 1))
   }
   #'
   #'#Here we generate our nrow(X) random numbers from a population with a mean that varies depending
@@ -209,8 +209,8 @@ test_that("eval_design_mc example code runs without errors", {
   #'#However, we could also specify this using a different random generator function by
   #'#doubling the standard deviation of the population we are drawing from:
   #'
-  rgensnr = function(X,b) {
-    return(rnorm(n=nrow(X), mean = X %*% b, sd = 2))
+  rgensnr = function(X, b, delta) {
+    return(rnorm(n=nrow(X), mean = X %*% b + delta, sd = 2))
   }
   #'
   expect_silent(eval_design_mc(RunMatrix=designcoffee, model=~cost + type + size, alpha=0.05,
@@ -253,17 +253,11 @@ test_that("eval_design_mc example code runs without errors", {
   #'#a variance ratio of one between the whole plots and the sub-plots.
   #'#See the accompanying paper _____ for further technical details.
   #'
-  rgenblocking = function(v) {
-    return(rnorm(n=1, mean = 0, sd = v))
-  }
-  #'
   blockvector = c(1,1)
   #'
   #'#Evaluate the design. Note the decreased power for the blocking factors. If
   expect_silent(eval_design_mc(RunMatrix=splitplotdesign, model=~Store+Temp+cost+type+size, alpha=0.05,
-                 nsim=100, glmfamily="gaussian", rfunction=rgen,blockfunction = rgenblocking,
-                 blocknoise = blockvector))
-  #'
+                 nsim=100, glmfamily="gaussian", rfunction=rgen, blocknoise = blockvector))
   #'
   #'#We can also use this method to evaluate designs that cannot be easily
   #'#evaluated using normal approximations. Here, we evaluate a design and see
@@ -276,8 +270,8 @@ test_that("eval_design_mc example code runs without errors", {
   #'#Here our random binomial generator simulates a response based on the resulting
   #'#probability from of all the columns in one row influencing the result.
   #'
-  rgenbinom = function(X,b) {
-    rbinom(n=nrow(X),size=1,prob = exp(X %*% b)/(1+exp(X %*% b)))
+  rgenbinom = function(X, b, delta) {
+    rbinom(n=nrow(X), size=1, prob = 1 / ( 1 + exp(-(X %*% b - delta))))
   }
   #'
   #'#Plugging everything in, we now evaluate our model and obtain the binomial power.
@@ -297,8 +291,8 @@ test_that("eval_design_mc example code runs without errors", {
   #'
   #'#Here we return a random poisson number of events that vary depending
   #'#on the rate in the design.
-  rrate = function(X,b) {
-    return(rpois(n=nrow(X),lambda=exp(X%*%b)))
+  rrate = function(X, b, delta) {
+    return(rpois(n=nrow(X), lambda=exp(X %*% b + delta)))
   }
   expect_silent(eval_design_mc(designpois,~a+b,0.2,nsim=100,glmfamily="poisson",rfunction=rrate,
                  anticoef=c(log(0.2),log(2),log(2))))

--- a/tests/testthat/testGenerateBlockNoise.R
+++ b/tests/testthat/testGenerateBlockNoise.R
@@ -1,0 +1,61 @@
+context("Test generate_block_noise")
+
+test_that("generate_block_noise works properly with character inputs", {
+  #library(plyr)
+
+  blockmatrix = cbind(c(1,1,1,1,2,2,2,2), c('a', 'a', 'b', 'b', 'c', 'c', 'd', 'd'), 1:8)
+  levs = alply(blockmatrix, 2, unique)
+  noiselevels = c(10, 1)
+  set.seed(1)
+  b1noise = rnorm(2, 0, noiselevels[1])
+  b2noise = rnorm(4, 0, noiselevels[2])
+  expected = rep(b1noise, each = 4) + rep(b2noise, each = 2)
+  set.seed(1)
+  output = generate_block_noise(blockmatrix, levs, noiselevels)
+  expect_equivalent(expected, output)
+})
+
+
+test_that("generate_block_noise works properly with numeric inputs", {
+  #library(plyr)
+
+  blockmatrix = cbind(rep(1:2, each = 4), rep(1:4, each = 2), 1:8)
+  levs = alply(blockmatrix, 2, unique)
+  noiselevels = c(10, 1)
+  set.seed(1)
+  b1noise = rnorm(2, 0, noiselevels[1])
+  b2noise = rnorm(4, 0, noiselevels[2])
+  expected = rep(b1noise, each = 4) + rep(b2noise, each = 2)
+  set.seed(1)
+  output = generate_block_noise(blockmatrix, levs, noiselevels)
+  expect_equivalent(expected, output)
+})
+
+test_that("generate_block_noise works non-consecutive levels", {
+  #library(plyr)
+  blockmatrix = cbind(rep(c(10, 20), each = 4), rep(c('shoe', 'hat', 'cape', 'post'), each = 2), 1:8)
+  levs = alply(blockmatrix, 2, unique)
+  noiselevels = c(10, 1)
+  set.seed(1)
+  b1noise = rnorm(2, 0, noiselevels[1])
+  b2noise = rnorm(4, 0, noiselevels[2])
+  expected = rep(b1noise, each = 4) + rep(b2noise, each = 2)
+  set.seed(1)
+  output = generate_block_noise(blockmatrix, levs, noiselevels)
+  expect_equivalent(expected, output)
+})
+
+
+test_that("generate_block_noise works with non-standard level structures", {
+  #library(plyr)
+  blockmatrix = cbind(rep(c(10, 20, 30, 40), each = 2), rep(c('shoe', 'hat', 'cape', 'post'), each = 2), 1:8)
+  levs = alply(blockmatrix, 2, unique)
+  noiselevels = c(10, 1)
+  set.seed(1)
+  b1noise = rnorm(length(levs[[1]]), 0, noiselevels[1])
+  b2noise = rnorm(length(levs[[2]]), 0, noiselevels[2])
+  expected = rep(b1noise, each = 2) + rep(b2noise, each = 2)
+  set.seed(1)
+  output = generate_block_noise(blockmatrix, levs, noiselevels)
+  expect_equivalent(expected, output)
+})


### PR DESCRIPTION
Added random blocking to eval_design_mc. Blocking is constrained to be a random intercept for each block. If we like this I can port it to survival_mc and custom_mc.

I wanted to get blocking working but I had trouble understanding your blocking code, so I wrote my own.  It's heavily based on yours, but I think I have a different data structure to encode the blocking. Not sure. Anyway, if you don't like it you don't have to keep it.

2 things: 
1) I had trouble getting replicate() to work, so I simulated the data in the for loop. If you can pull it out that would be fine.

2) eval_design and eval_design_mc give very different power numbers for designcoffee and splitplotdesign in the eval_design_mc example code. I couldn't figure out why. The blocking code doesn't get executed for designcoffee, so there's probably something deeper going on.