### PR TITLE
compute anticoef from delta or binomprobs, 

### DIFF
--- a/R/eval_design.R
+++ b/R/eval_design.R
@@ -150,6 +150,7 @@ eval_design = function(RunMatrix, model, alpha, blocking=FALSE, anticoef=NULL,
   if(length(anticoef) != dim(attr(RunMatrix,"modelmatrix"))[2] && !any(sapply(RunMatrix,class)=="factor")) {
     anticoef = rep(1,dim(attr(RunMatrix,"modelmatrix"))[2])
   }
+  anticoef = anticoef * delta / 2
 
   #-----Generate V inverse matrix-----X
 
@@ -190,14 +191,14 @@ eval_design = function(RunMatrix, model, alpha, blocking=FALSE, anticoef=NULL,
 
   #This returns if everything is continuous (no categorical)
   if (!any(table(attr(attr(RunMatrix,"modelmatrix"),"assign")[-1])!=1)) {
-    effectresults = parameterpower(RunMatrix,anticoef*delta/2,alpha,vInv = vInv)
+    effectresults = parameterpower(RunMatrix,anticoef,alpha,vInv = vInv)
     typevector = rep("effect.power",length(effectresults))
     namevector = colnames(attr(RunMatrix,"modelmatrix"))
 
     results = data.frame(parameters = namevector, type = typevector, power = effectresults)
 
     attr(results, "modelmatrix") = attr(RunMatrix,"modelmatrix")
-    attr(results, "anticoef") = anticoef*delta/2
+    attr(results, "anticoef") = anticoef
 
     modelmatrix_cor = model.matrix(model,RunMatrix,contrasts.arg=contrastslist_correlationmatrix)
     if(ncol(modelmatrix_cor) > 2) {
@@ -242,8 +243,8 @@ eval_design = function(RunMatrix, model, alpha, blocking=FALSE, anticoef=NULL,
   } else {
     levelvector = sapply(lapply(RunMatrix,unique),length)
 
-    effectresults = effectpower(RunMatrix,levelvector,anticoef*delta/2,alpha,vInv=vInv)
-    parameterresults = parameterpower(RunMatrix,anticoef*delta/2,alpha,vInv=vInv)
+    effectresults = effectpower(RunMatrix,levelvector,anticoef,alpha,vInv=vInv)
+    parameterresults = parameterpower(RunMatrix,anticoef,alpha,vInv=vInv)
 
     typevector = c(rep("effect.power",length(effectresults)),rep("parameter.power",length(parameterresults)))
     effectnamevector = c("(Intercept)",names(sapply(lapply(RunMatrix,unique),length)))
@@ -258,7 +259,7 @@ eval_design = function(RunMatrix, model, alpha, blocking=FALSE, anticoef=NULL,
     }
 
     attr(results, "modelmatrix") = attr(RunMatrix,"modelmatrix")
-    attr(results, "anticoef") = anticoef*delta/2
+    attr(results, "anticoef") = anticoef
 
     modelmatrix_cor = model.matrix(model,RunMatrix,contrasts.arg=contrastslist_correlationmatrix)
     if(ncol(modelmatrix_cor) > 2) {

--- a/R/eval_design.R
+++ b/R/eval_design.R
@@ -148,6 +148,7 @@ eval_design = function(RunMatrix, model, alpha, blocking=FALSE, anticoef=NULL,
     stop("Wrong number of anticipated coefficients")
   }
   if(length(anticoef) != dim(attr(RunMatrix,"modelmatrix"))[2] && !any(sapply(RunMatrix,class)=="factor")) {
+    warning("Wrong number of anticipated coefficients. Using delta instead.")
     anticoef = rep(1,dim(attr(RunMatrix,"modelmatrix"))[2])
   }
   anticoef = anticoef * delta / 2

--- a/R/eval_design.R
+++ b/R/eval_design.R
@@ -143,15 +143,11 @@ eval_design = function(RunMatrix, model, alpha, blocking=FALSE, anticoef=NULL,
   if(missing(anticoef)) {
     anticoef = gen_anticoef(RunMatrix,model)
   }
-
-  if(length(anticoef) != dim(attr(RunMatrix,"modelmatrix"))[2] && any(sapply(RunMatrix,class)=="factor")) {
+  anticoef = anticoef * delta / 2
+  if(length(anticoef) != dim(attr(RunMatrix,"modelmatrix"))[2]) {
     stop("Wrong number of anticipated coefficients")
   }
-  if(length(anticoef) != dim(attr(RunMatrix,"modelmatrix"))[2] && !any(sapply(RunMatrix,class)=="factor")) {
-    warning("Wrong number of anticipated coefficients. Using delta instead.")
-    anticoef = rep(1,dim(attr(RunMatrix,"modelmatrix"))[2])
-  }
-  anticoef = anticoef * delta / 2
+
 
   #-----Generate V inverse matrix-----X
 

--- a/R/eval_design_custom_mc.R
+++ b/R/eval_design_custom_mc.R
@@ -114,15 +114,13 @@ eval_design_custom_mc = function(RunMatrix, model, alpha, nsim, rfunction, fitfu
 
   # autogenerate anticipated coefficients
   if(missing(anticoef)) {
-    anticoef = gen_anticoef(RunMatrixReduced,model) * delta / 2
+    anticoef = gen_anticoef(RunMatrixReduced,model)
   }
-  if(length(anticoef) != dim(ModelMatrix)[2] && any(sapply(RunMatrixReduced,class)=="factor")) {
+  anticoef = anticoef * delta / 2
+  if(length(anticoef) != dim(ModelMatrix)[2]) {
     stop("Wrong number of anticipated coefficients")
   }
-  if(length(anticoef) != dim(ModelMatrix)[2] && !any(sapply(RunMatrixReduced,class)=="factor")) {
-    warning("Wrong number of anticipated coefficients. Using delta instead.")
-    anticoef = rep(1,dim(ModelMatrix)[2]) * delta / 2
-  }
+
 
   model_formula = update.formula(model, Y ~ .)
   nparam = ncol(ModelMatrix)

--- a/R/eval_design_custom_mc.R
+++ b/R/eval_design_custom_mc.R
@@ -114,13 +114,14 @@ eval_design_custom_mc = function(RunMatrix, model, alpha, nsim, rfunction, fitfu
 
   # autogenerate anticipated coefficients
   if(missing(anticoef)) {
-    anticoef = gen_anticoef(RunMatrixReduced,model)
+    anticoef = gen_anticoef(RunMatrixReduced,model) * delta / 2
   }
   if(length(anticoef) != dim(ModelMatrix)[2] && any(sapply(RunMatrixReduced,class)=="factor")) {
     stop("Wrong number of anticipated coefficients")
   }
   if(length(anticoef) != dim(ModelMatrix)[2] && !any(sapply(RunMatrixReduced,class)=="factor")) {
-    anticoef = rep(1,dim(ModelMatrix)[2])
+    warning("Wrong number of anticipated coefficients. Using delta instead.")
+    anticoef = rep(1,dim(ModelMatrix)[2]) * delta / 2
   }
 
   model_formula = update.formula(model, Y ~ .)
@@ -134,7 +135,7 @@ eval_design_custom_mc = function(RunMatrix, model, alpha, nsim, rfunction, fitfu
     for (j in 1:nsim) {
 
       #simulate the data.
-      RunMatrixReduced$Y = rfunction(ModelMatrix,anticoef*delta/2)
+      RunMatrixReduced$Y = rfunction(ModelMatrix,anticoef)
 
       #fit a model to the simulated data.
       fit = fitfunction(model_formula, RunMatrixReduced, contrastlist)
@@ -153,7 +154,7 @@ eval_design_custom_mc = function(RunMatrix, model, alpha, nsim, rfunction, fitfu
     power_estimates = foreach::foreach (i = 1:nsim, .combine = "rbind",.packages = parallelpackages) %dopar% {
       power_values = rep(0, ncol(ModelMatrix))
       #simulate the data.
-      RunMatrixReduced$Y = rfunction(ModelMatrix,anticoef*delta/2)
+      RunMatrixReduced$Y = rfunction(ModelMatrix,anticoef)
 
       #fit a model to the simulated data.
       fit = fitfunction(model_formula, RunMatrixReduced, contrastlist)

--- a/R/eval_design_mc.R
+++ b/R/eval_design_mc.R
@@ -184,13 +184,13 @@ eval_design_mc = function(RunMatrix, model, alpha,
 
   #-----Autogenerate Anticipated Coefficients---#
   if(missing(anticoef)) {
-    anticoef = gen_anticoef(RunMatrixReduced, model)
+    anticoef = gen_anticoef(RunMatrixReduced, model) * delta / 2
   }
   if(length(anticoef) != dim(ModelMatrix)[2] && any(lapply(RunMatrixReduced,class)=="factor")) {
     stop("Wrong number of anticipated coefficients")
   }
   if(length(anticoef) != dim(ModelMatrix)[2] && !any(lapply(RunMatrixReduced,class)=="factor")) {
-    anticoef = rep(1,dim(ModelMatrix)[2])
+    anticoef = rep(1,dim(ModelMatrix)[2]) * delta / 2
   }
   if(glmfamilyname == "binomial" && is.null(binomialprobs)) {
     warning("Warning: Binomial model using default (or user supplied) anticipated coefficients. Default anticipated coefficients can result in
@@ -198,7 +198,7 @@ eval_design_mc = function(RunMatrix, model, alpha,
             binomialprobs for more realistic effect sizes.")
   }
   if(glmfamilyname == "binomial" && !is.null(binomialprobs)) {
-    anticoef = gen_binomial_anticoef(anticoef,binomialprobs[1],binomialprobs[2])
+    anticoef = gen_binomial_anticoef(anticoef,binomialprobs[1],binomialprobs[2]) #ignore delta argument
   }
 
   #-------------- Blocking errors --------------#
@@ -249,10 +249,10 @@ eval_design_mc = function(RunMatrix, model, alpha,
   responses = matrix(ncol=nsim,nrow=nrow(ModelMatrix))
   if(blocking) {
     for(i in 1:nsim) {
-      responses[,i] = rfunction(ModelMatrix,anticoef*delta/2,rblocknoise(noise=varianceratios,groups=blockgroups))
+      responses[,i] = rfunction(ModelMatrix,anticoef,rblocknoise(noise=varianceratios,groups=blockgroups))
     }
   } else {
-    responses = replicate(nsim, rfunction(ModelMatrix,anticoef*delta/2,rep(0,nrow(ModelMatrix))))
+    responses = replicate(nsim, rfunction(ModelMatrix,anticoef,rep(0,nrow(ModelMatrix))))
   }
   #-------Update formula with random blocks------#
 
@@ -349,7 +349,7 @@ eval_design_mc = function(RunMatrix, model, alpha,
                     type="parameter.power.mc",
                     power=power_values)
   attr(retval, "modelmatrix") = ModelMatrix
-  attr(retval, "anticoef") = anticoef*delta/2
+  attr(retval, "anticoef") = anticoef
 
   modelmatrix_cor = model.matrix(model,RunMatrixReduced,contrasts.arg=contrastslist_correlationmatrix)
   if(ncol(modelmatrix_cor) > 2) {
@@ -368,7 +368,6 @@ eval_design_mc = function(RunMatrix, model, alpha,
     retval$trials = nrow(RunMatrix)
     retval$nsim = nsim
     retval$blocking = blocking
-    retval$delta = delta
   }
 
   colnames(estimates) = parameter_names

--- a/R/eval_design_mc.R
+++ b/R/eval_design_mc.R
@@ -199,7 +199,8 @@ eval_design_mc = function(RunMatrix, model, alpha,
             binomialprobs for more realistic effect sizes.")
   }
   if(glmfamilyname == "binomial" && !is.null(binomialprobs)) {
-    anticoef = gen_binomial_anticoef(anticoef,binomialprobs[1],binomialprobs[2]) #ignore delta argument
+    anticoef = gen_binomial_anticoef(gen_anticoef(RunMatrixReduced, model),
+                                     binomialprobs[1],binomialprobs[2]) #ignore delta argument
   }
 
   #-------------- Blocking errors --------------#

--- a/R/eval_design_mc.R
+++ b/R/eval_design_mc.R
@@ -190,6 +190,7 @@ eval_design_mc = function(RunMatrix, model, alpha,
     stop("Wrong number of anticipated coefficients")
   }
   if(length(anticoef) != dim(ModelMatrix)[2] && !any(lapply(RunMatrixReduced,class)=="factor")) {
+    warning("Wrong number of anticipated coefficients. Using delta instead.")
     anticoef = rep(1,dim(ModelMatrix)[2]) * delta / 2
   }
   if(glmfamilyname == "binomial" && is.null(binomialprobs)) {

--- a/R/eval_design_mc.R
+++ b/R/eval_design_mc.R
@@ -184,21 +184,21 @@ eval_design_mc = function(RunMatrix, model, alpha,
 
   #-----Autogenerate Anticipated Coefficients---#
   if(missing(anticoef)) {
-    anticoef = gen_anticoef(RunMatrixReduced, model) * delta / 2
+    anticoef = gen_anticoef(RunMatrixReduced, model)
   }
-  if(length(anticoef) != dim(ModelMatrix)[2] && any(lapply(RunMatrixReduced,class)=="factor")) {
+  anticoef = anticoef * delta / 2
+  if(length(anticoef) != dim(ModelMatrix)[2]) {
     stop("Wrong number of anticipated coefficients")
-  }
-  if(length(anticoef) != dim(ModelMatrix)[2] && !any(lapply(RunMatrixReduced,class)=="factor")) {
-    warning("Wrong number of anticipated coefficients. Using delta instead.")
-    anticoef = rep(1,dim(ModelMatrix)[2]) * delta / 2
   }
   if(glmfamilyname == "binomial" && is.null(binomialprobs)) {
     warning("Warning: Binomial model using default (or user supplied) anticipated coefficients. Default anticipated coefficients can result in
             large shifts in probability throughout the design space. It is recommended to specify probability bounds in the argument
             binomialprobs for more realistic effect sizes.")
   }
-  if(glmfamilyname == "binomial" && !is.null(binomialprobs)) {
+  if(!is.null(binomialprobs)) {
+    if (glmfamilyname != "binomial") {
+      stop("binomialprobs can only be used with glmfamilyname = \"binomial\"")
+    }
     anticoef = gen_binomial_anticoef(gen_anticoef(RunMatrixReduced, model),
                                      binomialprobs[1],binomialprobs[2]) #ignore delta argument
   }
@@ -370,6 +370,7 @@ eval_design_mc = function(RunMatrix, model, alpha,
     retval$trials = nrow(RunMatrix)
     retval$nsim = nsim
     retval$blocking = blocking
+    retval$delta = delta
   }
 
   colnames(estimates) = parameter_names

--- a/R/eval_design_survival_mc.R
+++ b/R/eval_design_survival_mc.R
@@ -139,13 +139,14 @@ eval_design_survival_mc = function(RunMatrix, model, alpha,
 
   # autogenerate anticipated coefficients
   if(missing(anticoef)) {
-    anticoef = gen_anticoef(RunMatrixReduced,model)
+    anticoef = gen_anticoef(RunMatrixReduced,model) * delta / 2
   }
   if(length(anticoef) != dim(ModelMatrix)[2] && any(sapply(RunMatrixReduced,class)=="factor")) {
     stop("Wrong number of anticipated coefficients")
   }
   if(length(anticoef) != dim(ModelMatrix)[2] && !any(sapply(RunMatrixReduced,class)=="factor")) {
-    anticoef = rep(1,dim(ModelMatrix)[2])
+    warning("Wrong number of anticipated coefficients. Using delta instead.")
+    anticoef = rep(1,dim(ModelMatrix)[2]) * delta / 2
   }
   nparam = ncol(ModelMatrix)
   RunMatrixReduced$Y = 1
@@ -156,7 +157,7 @@ eval_design_survival_mc = function(RunMatrix, model, alpha,
     for (j in 1:nsim) {
 
       #simulate the data.
-      anticoef_adjusted = anticoef*delta/2
+      anticoef_adjusted = anticoef
 
       RunMatrixReduced$Y = rfunctionsurv(ModelMatrix,anticoef_adjusted)
 
@@ -180,7 +181,7 @@ eval_design_survival_mc = function(RunMatrix, model, alpha,
       power_values = rep(0, ncol(ModelMatrix))
       #simulate the data.
 
-      anticoef_adjusted = anticoef*delta/2
+      anticoef_adjusted = anticoef
 
       RunMatrixReduced$Y = rfunctionsurv(ModelMatrix,anticoef_adjusted)
 

--- a/R/eval_design_survival_mc.R
+++ b/R/eval_design_survival_mc.R
@@ -139,15 +139,14 @@ eval_design_survival_mc = function(RunMatrix, model, alpha,
 
   # autogenerate anticipated coefficients
   if(missing(anticoef)) {
-    anticoef = gen_anticoef(RunMatrixReduced,model) * delta / 2
+    anticoef = gen_anticoef(RunMatrixReduced,model)
   }
-  if(length(anticoef) != dim(ModelMatrix)[2] && any(sapply(RunMatrixReduced,class)=="factor")) {
+  anticoef = anticoef * delta / 2
+  if(length(anticoef) != dim(ModelMatrix)[2]) {
     stop("Wrong number of anticipated coefficients")
   }
-  if(length(anticoef) != dim(ModelMatrix)[2] && !any(sapply(RunMatrixReduced,class)=="factor")) {
-    warning("Wrong number of anticipated coefficients. Using delta instead.")
-    anticoef = rep(1,dim(ModelMatrix)[2]) * delta / 2
-  }
+
+
   nparam = ncol(ModelMatrix)
   RunMatrixReduced$Y = 1
 


### PR DESCRIPTION
then only use anticoef later (not delta).

This improves code locality. It also fixes a bug in detailedoutput=TRUE, which did not properly show the anticipated coefficients if the user did not specify anticoef but instead used the delta argument.