### PR TITLE
Updated documentation

### DIFF
--- a/man/eval_design.Rd
+++ b/man/eval_design.Rd
@@ -2,49 +2,68 @@
 % Please edit documentation in R/eval_design.R
 \name{eval_design}
 \alias{eval_design}
-\title{Calculates Power Given a Run Matrix}
+\title{Calculate Power of an Experimental Design}
 \usage{
 eval_design(RunMatrix, model, alpha, blocking = FALSE, anticoef = NULL,
   delta = 2, varianceratios = 1, contrasts = contr.sum,
   conservative = FALSE, detailedoutput = FALSE)
 }
 \arguments{
-\item{RunMatrix}{The run matrix being evaluated.}
+\item{RunMatrix}{The run matrix being evaluated. Internally, \code{eval_design} rescales each numeric column
+to the range [-1, 1], so you do not need to do this scaling manually.}
 
 \item{model}{The model used in evaluating the design. It can be a subset of the model used to
-generate the design, or include higher order effects not in the original design generation.}
+generate the design, or include higher order effects not in the original design generation. It cannot include
+factors that are not present in the run matrix.}
 
 \item{alpha}{The specified type-I error.}
 
-\item{blocking}{Default FALSE. If TRUE, eval_design will look at the rownames to determine blocking structure.}
+\item{blocking}{If TRUE, \code{eval_design} will look at the rownames to determine blocking structure. Default FALSE.}
 
 \item{anticoef}{The anticipated coefficients for calculating the power. If missing, coefficients
-will be automatically generated based on the delta argument.}
+will be automatically generated based on the \code{delta} argument.}
 
-\item{delta}{The signal-to-noise ratio. Default 2. This specifies the difference between the high
-and low levels. If you do not specify anticoef, the anticipated coefficients will be half of delta. If you do specify anticoef, leave delta at its default of 2.}
+\item{delta}{The signal-to-noise ratio. Default 2. For continuous factors, this specifies the
+difference between the highest and lowest levels of the factor (which are -1 and +1 after \code{eval_design}
+normalizes the input data). If you do not specify \code{anticoef},
+the anticipated coefficients will be half of \code{delta}. If you do specify \code{anticoef}, leave \code{delta} at its default of 2.}
 
 \item{varianceratios}{Default 1. The ratio of the whole plot variance to the run-to-run variance. For designs with more than one subplot
 this ratio can be a vector specifying the variance ratio for each subplot. Otherwise, it will use a single value for all strata.}
 
-\item{contrasts}{A string specifying how to treat the contrasts in calculating the model matrix.}
+\item{contrasts}{The function to use to encode the categorical factors in the model matrix. Default \code{contr.sum}.}
 
-\item{conservative}{Default FALSE. Specifies whether default method for generating
+\item{conservative}{Specifies whether default method for generating
 anticipated coefficents should be conservative or not. TRUE will give the most conservative
-estimate of power by setting all but one level in a categorical factor's anticipated coefficients
-to zero.}
+estimate of power by setting all but one level in each categorical factor's anticipated coefficients
+to zero. Default FALSE.}
 
-\item{detailedoutput}{Default FALSE. Returns additional information about evaluation in results.}
+\item{detailedoutput}{If TRUE, return additional information about evaluation in results. Default FALSE.}
 }
 \value{
-A data frame with the parameters of the model, the type of power analysis, and the power.
+A data frame with the parameters of the model, the type of power analysis, and the power. Several
+design diagnostics are stored as attributes of the data frame. In particular,
+the \code{modelmatrix} attribute contains the model matrix that was used for power evaluation. This is
+especially useful if you want to specify the anticipated coefficients to use for power evaluation. The model
+matrix provides the order of the model coefficients, as well as the
+encoding used for categorical factors.
 }
 \description{
-Evaluates a design given a run matrix and returns
-a data frame of parameter and effect powers. Designs can
-consist of both continuous and categorical factors. Default
-assumes a signal-to-noise ratio of 2 (can be changed with the
-delta parameter).
+Evaluates the power of an experimental design, for normal response variables,
+given the design's run matrix and the statistical model to be fit to the data.
+Returns a data frame of parameter and effect powers. Designs can
+consist of both continuous and categorical factors. By default, \code{eval_design}
+assumes a signal-to-noise ratio of 2, but this can be changed with the
+\code{delta} or \code{anticoef} parameters.
+}
+\details{
+This function evaluates the power of experimental designs using standard theory
+as described in any DOE textbook. An accesible reference is "Optimal Design of
+Experiments: A Case Study Approach," by Goos and Jones (2011).
+
+When using \code{conservative = TRUE}, \code{eval_design} first evaluates the power with default coefficients. Then,
+for each multi-level categorical, it sets all coefficients to zero except the level that produced the lowest power,
+and then re-evaluates the power with this modified set of anticipated coefficients.
 }
 \examples{
 #Generating a simple 2x3 factorial to feed into our optimal design generation
@@ -56,7 +75,7 @@ optdesign = gen_design(candidateset=factorial, model= ~A+B+C,trials=11,optimalit
 #Now evaluating that design (with default anticipated coefficients and a delta of 2):
 eval_design(RunMatrix=optdesign, model= ~A+B+C, alpha=0.2)
 
-#Evaluating a subset of the design (changing the power due to a different number of
+#Evaluating a subset of the design (which changes the power due to a different number of
 #degrees of freedom)
 eval_design(RunMatrix=optdesign, model= ~A+C, alpha=0.2)
 
@@ -75,28 +94,29 @@ factorialcoffee = expand.grid(cost=c(1,2),
 designcoffee = gen_design(factorialcoffee,~cost + size + type,trials=29,optimality="D",repeats=100)
 
 #Evaluate the design, with default anticipated coefficients (conservative is FALSE by default).
-eval_design(designcoffee,model=~cost+size+type, alpha=0.05)
+#(Setting detailedoutput = T provides information on the anticipated coefficients that were used:)
+eval_design(designcoffee,model=~cost+size+type, alpha=0.05, detailedoutput = T)
 
 #Evaluate the design, with conservative anticipated coefficients:
-eval_design(designcoffee,model=~cost+size+type, alpha=0.05,conservative=TRUE)
+eval_design(designcoffee,model=~cost+size+type, alpha=0.05, detailedoutput = T, conservative=TRUE)
 
 #which is the same as the following, but now explicitly entering the coefficients:
-eval_design(designcoffee,model=~cost+size+type, alpha=0.05,anticoef=c(1,1,1,0,0,1,0))
+eval_design(designcoffee,model=~cost+size+type, alpha=0.05,anticoef=c(1,1,1,0,0,1,0), detailedoutput=T)
 
-#If the first level in a factor is not the one that you want to set to one
-#in the conservative calculation, enter the anticipated coefficients in manually.
+
+#If the defaults do not suit you, enter the anticipated coefficients in manually.
 eval_design(designcoffee,model=~cost+size+type, alpha=0.05,anticoef=c(1,1,0,0,1,0,1))
 
-#You can also evaluate the design with higher order effects:
+#You can also evaluate the design with higher order effects, even if they were not used in design generation:
 eval_design(designcoffee,model=~cost+size+type+cost*type, alpha=0.05)
 
 #Split plot designs can also be evaluated by setting the blocking parameter as TRUE.
 
 #Generating split plot design
 splitfactorialcoffee = expand.grid(caffeine=c(1,-1),
-                             cost=c(1,2),
-                             type=as.factor(c("Kona","Colombian","Ethiopian","Sumatra")),
-                             size=as.factor(c("Short","Grande","Venti")))
+                                   cost=c(1,2),
+                                   type=as.factor(c("Kona","Colombian","Ethiopian","Sumatra")),
+                                   size=as.factor(c("Short","Grande","Venti")))
 
 coffeeblockdesign = gen_design(splitfactorialcoffee, ~caffeine, trials=12)
 coffeefinaldesign = gen_design(splitfactorialcoffee, model=~caffeine+cost+size+type,trials=36,

--- a/man/eval_design_custom_mc.Rd
+++ b/man/eval_design_custom_mc.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/eval_design_custom_mc.R
 \name{eval_design_custom_mc}
 \alias{eval_design_custom_mc}
-\title{Evaluates power for model matrix with a Monte Carlo simulation for a user supplied library}
+\title{Monte Carlo power evaluation for experimental designs with user-supplied libraries}
 \usage{
 eval_design_custom_mc(RunMatrix, model, alpha, nsim, rfunction, fitfunction,
   pvalfunction, anticoef, delta = 2, contrasts = contr.sum,
@@ -10,9 +10,10 @@ eval_design_custom_mc(RunMatrix, model, alpha, nsim, rfunction, fitfunction,
   parallelpackages = NULL)
 }
 \arguments{
-\item{RunMatrix}{The run matrix of the design.}
+\item{RunMatrix}{The run matrix of the design. Internally, \code{eval_design_custom_mc} rescales each numeric column
+to the range [-1, 1].}
 
-\item{model}{The model used in the evaluation.}
+\item{model}{The statistical model used to fit the data.}
 
 \item{alpha}{The type-I error.}
 
@@ -21,26 +22,29 @@ eval_design_custom_mc(RunMatrix, model, alpha, nsim, rfunction, fitfunction,
 \item{rfunction}{Random number generator function. Should be a function of the form f(X,b), where X is the
 model matrix and b are the anticipated coefficients.}
 
-\item{fitfunction}{Function from library used to evaluate fit. Should be of the form f(formula, X, contrasts)
+\item{fitfunction}{Function used to fit the data. Should be of the form f(formula, X, contrasts)
 where X is the model matrix. If contrasts do not need to be specified for the user supplied
 library, that argument can be ignored.}
 
-\item{pvalfunction}{Function that returns a vector of pvals from the object returned from the fitfunction.}
+\item{pvalfunction}{Function that returns a vector of p-values from the object returned from the fitfunction.}
 
 \item{anticoef}{The anticipated coefficients for calculating the power. If missing, coefficients will be
-automatically generated.}
+automatically generated based on \code{delta}.}
 
-\item{delta}{The signal-to-noise ratio. Default 2. This specifies the difference between the high and low levels.
-Anticipated coefficients will be half of this number.}
+\item{delta}{Loosely speaking, the signal-to-noise ratio. Default 2. For a gaussian model, and for
+continuous factors, this specifies the difference in response between the highest
+and lowest levels of a factor (which are +1 and -1 after normalization).
+More precisely: If you do not specify \code{anticoef}, the anticipated coefficients will be
+half of \code{delta}. If you do specify \code{anticoef}, leave \code{delta} at its default of 2.}
 
-\item{contrasts}{Function used to generate the contrasts encoding for categorical variables. Default contr.sum.}
+\item{contrasts}{Function used to generate the contrasts encoding for categorical variables. Default \code{contr.sum}.}
 
 \item{coef_function}{Function that, when applied to a fitfunction return object, returns the estimated coefficients.}
 
 \item{parameternames}{Vector of parameter names if the coefficients do not correspond simply to the columns in the model matrix
 (e.g. coefficients from an MLE fit).}
 
-\item{parallel}{Default FALSE. If TRUE, uses all cores available to speed up computation of power.}
+\item{parallel}{If TRUE, uses all cores available to speed up computation of power. Default FALSE.}
 
 \item{parallelpackages}{A vector of strings listing the external packages to be input into the parallel package.}
 }
@@ -49,8 +53,10 @@ A data frame consisting of the parameters and their powers. The parameter estima
 stored in the 'estimates' attribute.
 }
 \description{
-Evaluates design given a model matrix with a monte carlo simulation and returns
-a data frame of parameter powers. Currently only works with linear, non-interacting models.
+Evaluates the power of an experimental design, given its run matrix and the
+statistical model to be fit to the data, using monte carlo simulation. Simulated data is fit using a
+user-supplied fitting library and power is estimated by the fraction of times a parameter is significant. Returns
+a data frame of parameter powers.
 }
 \examples{
 #To demonstrate how a user can use their own libraries for Monte Carlo power generation,

--- a/man/eval_design_mc.Rd
+++ b/man/eval_design_mc.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/eval_design_mc.R
 \name{eval_design_mc}
 \alias{eval_design_mc}
-\title{Evaluates power for model matrix with a Monte Carlo simulation}
+\title{Monte Carlo Power Evaluation for Experimental Designs}
 \usage{
 eval_design_mc(RunMatrix, model, alpha, blocking = FALSE, nsim = 1000,
   glmfamily = "gaussian", varianceratios = NULL, rfunction = NULL,
@@ -10,45 +10,91 @@ eval_design_mc(RunMatrix, model, alpha, blocking = FALSE, nsim = 1000,
   binomialprobs = NULL, parallel = FALSE, detailedoutput = FALSE)
 }
 \arguments{
-\item{RunMatrix}{The run matrix of the design.}
+\item{RunMatrix}{The run matrix of the design. Internally, \code{eval_design_mc} rescales each numeric column
+to the range [-1, 1].}
 
-\item{model}{The model used in the evaluation.}
+\item{model}{The model used in evaluating the design. It can be a subset of the model used to
+generate the design, or include higher order effects not in the original design generation. It cannot include
+factors that are not present in the run matrix.}
 
 \item{alpha}{The type-I error.}
 
-\item{blocking}{Default FALSE. Set to TRUE if design has blocking structure.}
+\item{blocking}{If TRUE, \code{eval_design_mc} will look at the rownames to determine blocking structure. Default FALSE.}
 
-\item{nsim}{The number of simulations.}
+\item{nsim}{The number of simulations to perform.}
 
 \item{glmfamily}{String indicating the family of distribution for the glm function
-(e.g. "gaussian", "binomial", "poisson")}
+("gaussian", "binomial", "poisson", or "exponential").}
 
 \item{varianceratios}{Default 1. The ratio of the whole plot variance to the run-to-run variance. For designs with more than one subplot
 this ratio can be a vector specifying the variance ratio for each subplot. Otherwise, it will use a single value for all strata.}
 
 \item{rfunction}{Random number generator function for the response variable. Should be a function of the form f(X, b, delta), where X is the
-model matrix, b are the anticipated coefficients, and delta is a vector of blocking errors. typically something like rnorm(nrow(X), X * b + delta, 0)}
+model matrix, b are the anticipated coefficients, and delta is a vector of blocking errors. Typically something like rnorm(nrow(X), X * b + delta, 0).
+You only need to specify this if you do not like the default behavior described below.}
 
 \item{anticoef}{The anticipated coefficients for calculating the power. If missing, coefficients
-will be automatically generated based on the delta argument.}
+will be automatically generated based on the \code{delta} or \code{binomialprobs} arguments.}
 
-\item{delta}{The signal-to-noise ratio. Default 2. This specifies the difference between the high
-and low levels. If you do not specify anticoef, the anticipated coefficients will be half of delta.}
+\item{delta}{Loosely speaking, the signal-to-noise ratio. Default 2. For a gaussian model, and for
+continuous factors, this specifies the difference in response between the highest
+and lowest levels of a factor (which are +1 and -1 after normalization).
+More precisely: If you do not specify \code{anticoef}, the anticipated coefficients will be
+half of \code{delta}. If you do specify \code{anticoef}, leave \code{delta} at its default of 2.}
 
-\item{contrasts}{The contrasts to use for categorical factors. Defaults to contr.sum.}
+\item{contrasts}{The contrasts to use for categorical factors. Defaults to \code{contr.sum}.}
 
-\item{binomialprobs}{Default NULL. If the glm family is binomial, user should specify a length-two vector consisting of the base probability and the maximum expected probability given all the level settings in the experiment. As an example, if the user wants to detect at an increase in successes from 0.5 to 0.8, the user would pass the vector c(0.5,0.8) to the argument}
+\item{binomialprobs}{If the glm family is binomial, user should specify
+a length-two vector consisting of the base probability and the maximum expected probability. Note that
+this effect size is applied to each parameter, so if you have many parameters the actual shift in probability
+across the design space can be much larger than this.
+As an example, if the user wants to detect at an
+change in success rate from 0.5 to 0.8, the user would pass the vector c(0.5,0.8) to the argument.
+If this argument is used, the \code{anticoef} and \code{delta} arguments are ignored.}
 
 \item{parallel}{Default FALSE. If TRUE, uses all cores available to speed up computation. WARNING: This can slow down computation if nonparallel time to complete the computation is less than a few seconds.}
 
-\item{detailedoutput}{Default FALSE. Returns additional information about evaluation in results.}
+\item{detailedoutput}{If TRUE, return additional information about evaluation in results.}
 }
 \value{
-A data frame consisting of the parameters and their powers. The parameter estimates from the simulations are stored in the 'estimates' attribute.
+A data frame consisting of the parameters and their powers, with supplementary information
+stored in the data frame's attributes. The parameter estimates from the simulations are stored in the "estimates"
+attribute. The "modelmatrix" attribute contains the model matrix that was used for power evaluation, and
+also provides the encoding used for categorical factors. If you want to specify the anticipated
+coefficients manually, do so in the order the parameters appear in the model matrix.
 }
 \description{
-Evaluates design, given a run matrix, with a monte carlo simulation and returns
-a data frame of parameter and effect powers.
+Evaluates the power of an experimental design, given its run matrix and the
+statistical model to be fit to the data, using monte carlo simulation. Simulated data is fit using a
+generalized linear model
+and power is estimated by the fraction of times a parameter is significant. Returns
+a data frame of parameter powers.
+}
+\details{
+Evaluates the power of a design with Monte Carlo simulation. Data is simulated and then fit
+with a generalized linear model, and the fraction of simulations in which a parameter is
+significant is the estimate of power for that parameter.
+
+First, the random noise from blocking is generated with \code{rnorm}.
+Each block gets a single sample of Gaussian random noise, with a variance as specified in \code{varianceratios},
+and that sample is copied to each run in the block. Then, \code{rfunction} is called to generate a simulated
+response for each run of the design, and the data is fit using the appropriate fitting function.
+The functions used to simulate the data and fit it are determined by the \code{glmfamily}
+and \code{blocking} arguments
+as follows. Below, X is the model matrix, b is the anticipated coefficients, and d
+is a vector of blocking noise:
+
+\tabular{llrr}{
+\bold{glmfamily}      \tab \bold{blocking} \tab \bold{rfunction} \tab \bold{fit} \cr
+"gaussian"     \tab F        \tab \code{rnorm(mean = X \%*\% b + d, sd = 1)}        \tab \code{lm}         \cr
+"gaussian"     \tab T        \tab \code{rnorm(mean = X \%*\% b + d, sd = 1)}        \tab \code{lme4::lmer} \cr
+"binomial"     \tab F        \tab \code{rbinom(prob = 1/(1+exp(-(X \%*\% b + d))))} \tab \code{glm(family = "binomial")}  \cr
+"binomial"     \tab T        \tab \code{rbinom(prob = 1/(1+exp(-(X \%*\% b + d))))} \tab \code{lme4::glmer(family = "binomial")} \cr
+"poisson"      \tab F        \tab \code{rpois(lambda = exp((X \%*\% b + d)))}       \tab \code{glm(family = "poisson")}         \cr
+"poisson"      \tab T        \tab \code{rpois(lambda = exp((X \%*\% b + d)))}       \tab \code{lme4::glmer(family = "poisson")} \cr
+"exponential"  \tab F        \tab \code{rexp(rate = exp(-(X \%*\% b + d)))}            \tab \code{glm(family = Gamma(link="log"))} \cr
+"exponential"  \tab T        \tab \code{rexp(rate = exp(-(X \%*\% b + d)))}            \tab \code{lme4:glmer(family = Gamma(link="log"))} \cr
+}
 }
 \examples{
 #We first generate a full factorial design using expand.grid:
@@ -67,7 +113,7 @@ eval_design(RunMatrix=designcoffee, model=~cost + type + size, 0.05)
 
 #To evaluate this design with a Monte Carlo method, we enter the same information
 #used in eval_design, with the addition of the number of simulations "nsim" and the distribution
-#family used in fitting for the glm "glmfamily". For gaussian, binomial, expontial, and poisson
+#family used in fitting for the glm "glmfamily". For gaussian, binomial, exponential, and poisson
 #families, a default random generating function (rfunction) will be supplied. If another glm
 #family is used or the default random generating function is not adequate, a custom generating
 #function can be supplied by the user.
@@ -117,32 +163,35 @@ splitplotdesign = gen_design(candidateset=factorialcoffee2,
 #each split-plot level. This is equivalent to specifying a variance ratio of one between
 #the whole plots and the sub-plots for gaussian models.
 
-#Evaluate the design. Note the decreased power for the blocking factors. If
+#Evaluate the design. Note the decreased power for the blocking factors.
 eval_design_mc(RunMatrix=splitplotdesign, model=~Store+Temp+cost+type+size, alpha=0.05,
               nsim=100, glmfamily="gaussian", varianceratios = c(1,1))
 
 #We can also use this method to evaluate designs that cannot be easily
 #evaluated using normal approximations. Here, we evaluate a design with a binomial response and see
-#if we can detect the difference between each factor changing whether an event
+#whether we can detect the difference between each factor changing whether an event occurs
 #70\% of the time or 90\% of the time.
 
 factorialbinom = expand.grid(a=c(-1,1),b=c(-1,1))
 designbinom = gen_design(factorialbinom,model=~a+b,trials=90,optimality="D",repeats=100)
 
-eval_design_mc(designbinom,~a+b,alpha=0.2,nsim=100,anticoef=c(1.5,0.7,0.7),
+eval_design_mc(designbinom,~a+b,alpha=0.2,nsim=100, binomialprobs = c(0.7, 0.9),
               glmfamily="binomial")
 
 #We can also use this method to determine power for poisson response variables.
-#We design our test to detect if each factor changes the base rate of 0.2 by
-#a factor of 2. We generate the design:
+Generate the design:
 
 factorialpois = expand.grid(a=as.numeric(c(-1,0,1)),b=c(-1,0,1))
-designpois = gen_design(factorialpois, ~a+b, trials=90, optimality="D", repeats=100)
+designpois = gen_design(factorialpois, ~a+b, trials=70, optimality="D", repeats=100)
 
-eval_design_mc(designpois,~a+b,0.2,nsim=100,glmfamily="poisson", anticoef=c(log(0.2),log(2),log(2)))
+Evaluate the power:
 
-#where the anticipated coefficients are chosen to set the base rate at 0.2
-#(from the intercept) as well as how each factor changes the rate (a factor of 2, so log(2)).
-#We see here we need about 90 test events to get accurately distinguish the three different
-#rates in each factor to 90\% power.
+eval_design_mc(designpois, ~a+b, 0.05, nsim=1000, glmfamily="poisson",
+               anticoef=log(c(0.2, 2, 2)))
+
+
+The coefficients above set the nominal value -- that is, the expected count when all inputs = 0 -- to 0.2
+(from the intercept), and say that each factor changes this count by a factor of 4
+(multiplied by 2 when x= +1, and divided by 2 when x = -1). Note the use of log() in the anticipated
+coefficients.
 }

--- a/man/eval_design_survival_mc.Rd
+++ b/man/eval_design_survival_mc.Rd
@@ -10,47 +10,65 @@ eval_design_survival_mc(RunMatrix, model, alpha, nsim = 1000,
   contrasts = contr.sum, parallel = FALSE, detailedoutput = FALSE, ...)
 }
 \arguments{
-\item{RunMatrix}{The run matrix of the design.}
+\item{RunMatrix}{The run matrix of the design. Internally, all numeric columns will be rescaled to [-1, +1].}
 
-\item{model}{The model used in the evaluation.}
+\item{model}{The statistical model used to fit the data.}
 
 \item{alpha}{The type-I error.}
 
-\item{nsim}{Default 1000. The number of simulations.}
+\item{nsim}{The number of simulations. Default 1000.}
 
-\item{distribution}{Default "gaussian". Distribution of survival function.}
+\item{distribution}{Distribution of survival function to use when fitting the data. Valid choices are described
+in the documentation for \code{survreg}. \emph{Supported} options are
+"exponential", "lognormal", or "gaussian". Default "gaussian".}
 
-\item{censorpoint}{Default NA for no censoring. The point after/before (for right censored or left censored data, respectively)
-which data should be labelled as censored.}
+\item{censorpoint}{The point after/before (for right-censored or left-censored data, respectively)
+which data should be labelled as censored. Default NA for no censoring.}
 
-\item{censortype}{Default "right". The type of censoring (either "left" or "right")}
+\item{censortype}{The type of censoring (either "left" or "right"). Default "right".}
 
-\item{rfunctionsurv}{Default NULL. Random number generator function. Should be a function of the form f(X,b), where X is the
-model matrix and b are the anticipated coefficients. This function should return a Surv object from
-the survival package. This is available if the user wants to add their own distribution not interally supported
-or modify the existing random generation functions.}
+\item{rfunctionsurv}{Random number generator function. Should be a function of the form f(X,b), where X is the
+model matrix and b are the anticipated coefficients. This function should return a \code{Surv} object from
+the \code{survival} package. You do not need to provide this argument if \code{distribution} is one of
+the supported choices and you are satisfied with the default behavior described below.}
 
 \item{anticoef}{The anticipated coefficients for calculating the power. If missing, coefficients
-will be automatically generated based on the delta argument.}
+will be automatically generated based on the \code{delta} argument.}
 
-\item{delta}{The signal-to-noise ratio. Default 2. This specifies the difference between the high
-and low levels. If you do not specify anticoef, the anticipated coefficients will be half of delta}
+\item{delta}{The signal-to-noise ratio. For a gaussian model, this specifies the difference in
+response between the highest and lowest levels of a factor (which are +1 and -1, respectively, after normalization).
+If you do not specify \code{anticoef}, the anticipated coefficients will be half of \code{delta}. Default 2.}
 
-\item{contrasts}{Function used to generate the contrasts encoding for categorical variables. Default contr.sum.}
+\item{contrasts}{Function used to encode categorical variables in the model matrix. Default \code{contr.sum}.}
 
-\item{parallel}{Default FALSE. If TRUE, uses all cores available to speed up computation of power.}
+\item{parallel}{If TRUE, uses all cores available to speed up computation of power. Default FALSE.}
 
-\item{detailedoutput}{Default FALSE. Returns additional information about evaluation in results.}
+\item{detailedoutput}{If TRUE, return additional information about evaluation in results. Default FALSE.}
 
-\item{...}{Any additional arguments to be input into the survreg function during fitting.}
+\item{...}{Any additional arguments to be passed into the \code{survreg} function during fitting.}
 }
 \value{
 A data frame consisting of the parameters and their powers. The parameter estimates from the simulations are
-stored in the 'estimates' attribute.
+stored in the 'estimates' attribute. The 'modelmatrix' attribute contains the model matrix and the encoding used for
+categorical factors. If you manually specify anticipated coefficients, do so in the order of the model matrix.
 }
 \description{
-Evaluates power for a right censored survival design with a Monte Carlo simulation,
-using the survival package and survreg to fit the data.
+Evaluates power for an experimental design in which the response variable may be
+right- or left-censored. Power is evaluated with a Monte Carlo simulation,
+using the \code{survival} package and \code{survreg} to fit the data. Split-plot designs are not supported.
+}
+\details{
+If not supplied by the user, \code{rfunctionsurv} will be generated based on the \code{distribution}
+argument as follows:
+\tabular{lr}{
+\bold{distribution}  \tab \bold{generating function} \cr
+"gaussian"                  \tab \code{rnorm(mean = X \%*\% b, sd=1)}           \cr
+"exponential"               \tab \code{rexp(rate = exp(-X \%*\% b))}           \cr
+"lognormal"                 \tab \code{rlnorm(meanlog= X \%*\% b, sdlog=1)}           \cr
+}
+
+In each case, if a simulated data point is past the censorpoint (greater than for right-censored, less than for
+left-censored) it is marked as censored. See the examples below for how to construct your own function.
 }
 \examples{
 #These examples focus on the survival analysis case and assume familiarity

--- a/man/gen_design.Rd
+++ b/man/gen_design.Rd
@@ -2,8 +2,7 @@
 % Please edit documentation in R/gen_design.R
 \name{gen_design}
 \alias{gen_design}
-\title{Generates the optimal run matrix from candidate set, model, optimality criterion,
-and desired number of runs.}
+\title{Generate optimal experimental designs}
 \usage{
 gen_design(candidateset, model, trials, splitplotdesign = NULL,
   splitplotsizes = NULL, optimality = "D", repeats = 10,
@@ -11,98 +10,107 @@ gen_design(candidateset, model, trials, splitplotdesign = NULL,
   minDopt = 0.95, parallel = FALSE, timer = FALSE, splitcolumns = FALSE)
 }
 \arguments{
-\item{candidateset}{A data frame of candidate test points. Usually this is a full factorial test matrix
-generated for the factors in the model, but if you have disallowed combinations then make sure the candidate list
-is consistent with them (e.g. by generating a full factorial and then removing disallowed combinations). If
-the factor is continuous, it should be type numeric. If the factor is categorical, it should be
-set as a factor.}
+\item{candidateset}{A data frame of candidate test points; each run of the optimal design will be chosen (with replacement)
+from this candidate set. Each row of the data frame is a candidate test point, with factor settings indicated in each column.
+No repeated rows allowed! Usually this is a full factorial test matrix
+generated for the factors in the model, but if you have disallowed combinations then make sure the candidate set
+is consistent with them (e.g. by generating a full factorial and then removing disallowed combinations).
+If a factor is continuous, its column should be type \code{numeric}. If a factor is categorical, its column should be type \code{factor}.}
 
-\item{model}{The model used to generate the test design.}
+\item{model}{The statistical model used to generate the test design.}
 
 \item{trials}{The number of runs in the design.}
 
-\item{splitplotdesign}{For a split-plot design, this is the design for all of the factors harder to change
-than the current set of factors. These rows are replicated to the specified size for each block
-(given in the argument splitplotsizes) and the optimal design is found for all of the factors given in the
-candidateset argument, taking into consideration the fixed and replicated hard-to-change factors.}
+\item{splitplotdesign}{If NULL, a fully randomized design is generated. If not NULL, a split-plot design is generated, and
+this argument specifies the design for
+all of the factors harder to change than the current set of factors.
+Each row corresponds to a block in which the harder to change factors will be held
+constant. Each row of \code{splitplotdesign} will be replicated as specified in \code{splitplotsizes},
+and the optimal design is found for all of the factors given in the
+\code{model} argument, taking into consideration the fixed and replicated hard-to-change factors.}
 
 \item{splitplotsizes}{Specifies the block size for each row of harder-to-change factors given in the
-argument splitplotdesign. If the input is a vector, each entry of the vector determines the size of the sub-plot
-for that whole plot setting. If the input is an integer, it generates a balanced design with equal-sized blocks.}
+argument \code{splitplotdesign}. If the input is a vector, each entry of the vector determines the size of the sub-plot
+for that whole plot setting. If the input is an integer, each block will be of this size.}
 
 \item{optimality}{Default "D". The optimality criterion used in generating the design. For split-plot designs, skpr currently
-only supports the D, I, A, and E criteria. Full list of supported criteria: "D", "I", "A", "Alias", "G", "T", or "E"}
+only supports the "D", "I", "A", and "E" criteria. Full list of supported criteria: "D", "I", "A", "Alias", "G", "T", or "E".}
 
-\item{repeats}{The number of times to repeat the search for the best optimal condition. If missing, this defaults to 10.}
+\item{repeats}{The number of times to repeat the search for the best optimal design. Default 10.}
 
-\item{varianceratio}{Default 1. The ratio between the interblock and intra-block variance for a given stratum in
-a split plot design.}
+\item{varianceratio}{The ratio between the interblock and intra-block variance for a given stratum in
+a split plot design. Default 1.}
 
-\item{contrast}{Function used to generate the contrasts encoding for categorical variables. Default contr.simplex.}
+\item{contrast}{Function used to generate the encoding for categorical variables. Default contr.simplex.}
 
-\item{aliaspower}{Default 2. Degree of interactions to be used in calculating the alias matrix for alias optimal designs.}
+\item{aliaspower}{Degree of interactions to be used in calculating the alias matrix for alias optimal designs. Default 2.}
 
-\item{minDopt}{Default 0.95. Minimum value for the D-Optimality of a design when searching for alias optimal designs.}
+\item{minDopt}{Minimum value for the D-Optimality of a design when searching for alias optimal designs. Default 0.95.}
 
-\item{parallel}{Default FALSE. If TRUE, the optimal design search will use all the available cores. This can lead to a substantial speed-up, for complex designs.}
+\item{parallel}{If TRUE, the optimal design search will use all the available cores. This can lead to a substantial speed-up in the search for complex designs. Default FALSE.}
 
-\item{timer}{Default FALSE. If TRUE, will print an estimate of the optimal design search time.}
+\item{timer}{If TRUE, will print an estimate of the optimal design search time. Default FALSE.}
 
-\item{splitcolumns}{Default FALSE. If TRUE, will convert row name split-plot structure to columns to output the design in a ready-to-analyze format. If no blocking is detected, no columns will be added.}
+\item{splitcolumns}{The blocking structure of the design will be indicated in the row names of the returned
+design. If TRUE, the design also will have extra columns to indicate the blocking structure. If no blocking is detected, no columns will be added. Default FALSE.}
 }
 \value{
-The optimal design. Attributes can be accessed with the attr function.
+A data frame containing the run matrix for the optimal design. The returned data frame contains supplementary
+information in its attributes, which can be accessed with the attr function.
 }
 \description{
-Creates design given a model and desired number of runs, returning the model matrix. Currently
-Used with eval_design/eval_design_mc to produce power estimations for designs.
+Creates an experimental design given a model, desired number of runs, and a data frame of candidate
+test points. \code{gen_design} chooses points from the candidate set and returns a design that is optimal for the given
+statistical model.
+}
+\details{
+Split-plot designs can be generated with repeated applications of \code{gen_design}; see examples for details.
 }
 \examples{
-#Generate the basic factorial design used in generating the optimal design with expand.grid.
-#Generating a basic 2 factor design:
-basicdesign = expand.grid(x1=c(-1,1), x2=c(-1,1))
+#Generate the basic factorial candidate set with expand.grid.
+#Generating a basic 2 factor candidate set:
+basic_candidates = expand.grid(x1=c(-1,1), x2=c(-1,1))
 
 #This candidate set is used as an input in the optimal design generation for a
 #D-optimal design with 11 runs.
-design = gen_design(candidateset=basicdesign, model=~x1+x2, trials=11)
+design = gen_design(candidateset=basic_candidates, model=~x1+x2, trials=11)
 
-#We can also use the dot operator to automatically use all of the terms in the model:
-design = gen_design(candidateset=basicdesign, model=~., trials=11)
+#We can also use the dot formula to automatically use all of the terms in the model:
+design = gen_design(candidateset=basic_candidates, model=~., trials=11)
 
 #Here we add categorical factors, specified by using "as.factor" in expand.grid:
-categoricaldesign = expand.grid(a=c(-1,1), b=as.factor(c("A","B")),
-                               c=as.factor(c("High","Med","Low")))
+categorical_candidates = expand.grid(a=c(-1,1),
+                                     b=as.factor(c("A","B")),
+                                     c=as.factor(c("High","Med","Low")))
 
 #This candidate set is used as an input in the optimal design generation.
-design2 = gen_design(candidateset=categoricaldesign, model=~a+b+c, trials=19)
+design2 = gen_design(candidateset=categorical_candidates, model=~a+b+c, trials=19)
 
 #We can also increase the number of times the algorithm repeats
 #the search to increase the probability that the globally optimal design was found.
-design2 = gen_design(candidateset=categoricaldesign, model=~a+b+c, trials=19, repeats=100)
+design2 = gen_design(candidateset=categorical_candidates, model=~a+b+c, trials=19, repeats=100)
 
 #You can also use a higher order model when generating the design:
-design2 = gen_design(candidateset=categoricaldesign, model=~a+b+c+a*b*c, trials=12)
+design2 = gen_design(candidateset=categorical_candidates, model=~a+b+c+a*b*c, trials=12)
 
 #To evaluate a response surface design, include center points
-#in the candidate set and do not include
-#quadratic effects with categorical factors.
+#in the candidate set and include quadratic effects (but not for the categorical factors).
 
-designquad = expand.grid(a=c(1,0,-1), b=c(-1,0,1), c=c("A","B","C"))
+quad_candidates = expand.grid(a=c(1,0,-1), b=c(-1,0,1), c=c("A","B","C"))
 
-gen_design(designquad, ~a+b+I(a^2)+I(b^2)+a*b*c, 20)
+gen_design(quad_candidates, ~a+b+I(a^2)+I(b^2)+a*b*c, 20)
 
 #The optimality criterion can also be changed:
-gen_design(designquad, ~a+b+I(a^2)+I(b^2)+a*b*c, 20,optimality="I")
-gen_design(designquad, ~a+b+I(a^2)+I(b^2)+a*b*c, 20,optimality="A")
+gen_design(quad_candidates, ~a+b+I(a^2)+I(b^2)+a*b*c, 20, optimality="I")
+gen_design(quad_candidates, ~a+b+I(a^2)+I(b^2)+a*b*c, 20, optimality="A")
 
 #A split-plot design can be generated by first generating an optimal blocking design using the
-#hard-to-change factors and then using that as the input for the split-plots design.
+#hard-to-change factors and then using that as the input for the split-plot design.
 #This generates an optimal subplot design that accounts for the existing split-plot settings.
-#See the accompannying paper "___________" for details of the implementation.
 
 splitplotcandidateset = expand.grid(Altitude=c(-1,1),
-                                   Range=as.factor(c("Close","Medium","Far")),
-                                   Power=c(1,-1))
+                                    Range=as.factor(c("Close","Medium","Far")),
+                                    Power=c(1,-1))
 hardtochangedesign = gen_design(candidateset = splitplotcandidateset, model=~Altitude, trials=11)
 
 #Now we can use the D-optimal blocked design as an input to our full design.
@@ -114,37 +122,44 @@ hardtochangedesign = gen_design(candidateset = splitplotcandidateset, model=~Alt
 #sum of all of the block sizes or else the program will throw an error.
 
 #Since we have 11 runs in our hard-to-change design, we need a vector
-#specifying the size of each 11 runs. Here we specify the blocks be three runs each
+#specifying the size of each of the 11 blocks. Here we specify the blocks should be three runs each
 #(meaning the final design will be 33 runs):
 
 splitplotblocksize = rep(3,11)
 
 #Putting this all together:
 designsplitplot = gen_design(splitplotcandidateset, ~Altitude+Range+Power, trials=33,
-                            splitplotdesign=hardtochangedesign,
-                            splitplotsizes = splitplotblocksize)
+                             splitplotdesign=hardtochangedesign,
+                             splitplotsizes=splitplotblocksize)
 
 #The split-plot structure is encoded into the row names, with a period
 #demarcating the blocking level. This process can be repeated for arbitrary
 #levels of blocking (i.e. a split-plot design can be entered in as the hard-to-change
 #to produce a split-split-plot design, which can be passed as another
 #hard-to-change design to produce a split-split-split plot design, etc).
+#In the following, note that the model builds up as we build up split plot strata.
 
-splitplotcandidateset2 = expand.grid(Location=as.character(c("East","West")),
-                                 Climate = as.factor(c("Dry","Wet","Arid")),
-                                 Vineyard = as.factor(c("A","B","C","D")),
-                                 Age = c(1,-1))
+splitplotcandidateset2 = expand.grid(Location = as.factor(c("East","West")),
+                                     Climate = as.factor(c("Dry","Wet","Arid")),
+                                     Vineyard = as.factor(c("A","B","C","D")),
+                                     Age = c(1,-1))
+#6 blocks of \\code{Location}:
+temp = gen_design(splitplotcandidateset2, ~Location, trials=6,varianceratio=2)
 
-gen_design(splitplotcandidateset2, ~Location, trials=6,varianceratio=2) -> temp
-gen_design(splitplotcandidateset2, ~Location+Climate,
-          trials=12, splitplotdesign = temp, splitplotsizes=rep(2,6),
-          varianceratio=1) -> temp
-gen_design(splitplotcandidateset2, ~Location+Climate+Vineyard,
-          trials=48, splitplotdesign = temp, splitplotsizes = rep(4,12),
-          varianceratio=1) -> temp
-gen_design(splitplotcandidateset2, ~Location+Climate+Vineyard+Age,
-         trials=192, splitplotdesign = temp, splitplotsizes = rep(4,48),
-          varianceratio=1) -> splitsplitsplitplotdesign
+#Each \\code{Location} block has 2 blocks of \\code{climate}:
+temp = gen_design(splitplotcandidateset2, ~Location+Climate,
+                  trials=12, splitplotdesign = temp, splitplotsizes=2,
+                  varianceratio=1)
+
+#Each \\code{climate} block has 4 blocks of \\code{Vineyard}:
+temp = gen_design(splitplotcandidateset2, ~Location+Climate+Vineyard,
+                  trials=48, splitplotdesign = temp, splitplotsizes = 4,
+                  varianceratio=1)
+
+#Each \\code{Vineyard} block has 4 runs with different \\code{Age}:
+splitsplitsplitplotdesign = gen_design(splitplotcandidateset2, ~Location+Climate+Vineyard+Age,
+                                       trials=192, splitplotdesign = temp, splitplotsizes = 4,
+                                       varianceratio=1, splitcolumns=T)
 
 #A design's diagnostics can be accessed via the following attributes:
 


### PR DESCRIPTION
Also changed class(runmatrix[,col]) == "numeric" to is.numeric(runmatrix[,col]) in a few places.

Oh, by the way, I changed our rfunctions, when using exponential, to be rexp(rate = exp(- X %*% b)). It was already like that in eval_design_survival_mc, and I changed eval_design_mc to match. Turns out both glm and survreg use that parameterization.  And I think that is the more natural way to think about it, since then you are basically saying lambda (= mean value = 1/rate) = exp(X %*% b).