### PR TITLE
add user specified alias optimality function

### DIFF
--- a/R/gen_design.R
+++ b/R/gen_design.R
@@ -288,6 +288,11 @@ gen_design = function(candidateset, model, trials,
     } else {
       progressBarUpdater = NULL
     }
+     if (!is.null(advancedoptions$amodel)) {
+      amodel = advancedoptions$amodel
+    } else {
+      amodel = NULL
+    }
   } else {
     advancedoptions = list()
     advancedoptions$GUI = FALSE
@@ -635,12 +640,13 @@ gen_design = function(candidateset, model, trials,
     }
   }
 
-  if (is.null(splitplotdesign)) {
-    amodel = aliasmodel(model, aliaspower)
-  } else {
-    amodel = aliasmodel(modelnowholeformula, aliaspower)
+  if(is.null(amodel)){
+   if (is.null(splitplotdesign)) {
+     amodel = aliasmodel(model, aliaspower)
+   } else {
+     amodel = aliasmodel(modelnowholeformula, aliaspower)
+   }
   }
-
   if (model == amodel && optimality == "ALIAS") {
     stop(paste0(c("Alias optimal selected, but full model specified with no aliasing at current aliaspower: ",
                   aliaspower, ". Try setting aliaspower = ", aliaspower + 1), collapse = ""))


### PR DESCRIPTION
Adds advancedoptions option of being able to specify a specific formula for alias optimal design.  This would allow users to specify only some two factor interactions to use in the alias model instead of all two factor interactions.  