### PR TITLE
Move definitions out of header files

### DIFF
--- a/src/nullify_alg.cpp
+++ b/src/nullify_alg.cpp
@@ -1,0 +1,98 @@
+#include <RcppEigen.h>
+
+Eigen::VectorXi sample_replace(int max_value, int size) {
+  Eigen::VectorXi index(size);
+  for (int i = 0; i < size; i++) {
+    index(i) = max_value * unif_rand();
+  }
+  return(index);
+}
+
+//sample without replacement
+Eigen::VectorXi sample_noreplace(int max_value, int size) {
+  if(size > max_value) {
+    throw std::range_error("argument `size` cannot be greater than `max_value` when sampling without replacment");
+  }
+  int i, j;
+  Eigen::VectorXi index(size);
+  Eigen::VectorXi sub(max_value);
+  for (i = 0; i < max_value; i++) {
+    sub(i) = i;
+  }
+  for (i = 0; i < size; i++) {
+    j = max_value * unif_rand();
+    index(i) = sub(j);
+    sub(j) = sub(--max_value);
+  }
+  return(index);
+}
+
+int longest_row(const Eigen::MatrixXd& V, const std::vector<bool>& rows_used) {
+  //Return the index of the longest unused row in V
+  double longest = -1;
+  int index = 0;
+  for (int i = 0; i < V.rows(); i++) {
+    if (!rows_used[i]) {
+      double this_len = V.row(i).dot(V.row(i));
+      if (this_len > longest) {
+        longest = this_len;
+        index = i;
+      }
+    }
+  }
+  return index;
+}
+
+
+void orthogonalize_input(Eigen::MatrixXd& X, int basis_row, const std::vector<bool>& rows_used) {
+  //Gram-Schmidt orthogonalize <X> - in place - with respect to its rownumber <basis_row>
+  //Only unused rows (as indicated by <rows_used>) are considered.
+  double basis_norm = X.row(basis_row).dot(X.row(basis_row));
+  for (int i = 0; i < X.rows(); i++) {
+    if (!rows_used[i]) {
+      double dotprod = X.row(i).dot(X.row(basis_row));
+      X.row(i) -= X.row(basis_row)*dotprod/basis_norm;
+    }
+  }
+}
+
+
+Eigen::VectorXi orthogonal_initial(const Eigen::MatrixXd& candidatelist, int nTrials) {
+  //Construct a nonsingular design matrix from candidatelist using the nullify procedure
+  //Returns a vector of rownumbers indicating which runs from candidatelist to use
+  //These rownumbers are not shuffled; you must do that yourself if randomizing the order is important
+  //If we cannot find a nonsingular design, returns a vector of zeros.
+
+  //First, find the p rows that come from the nullify procedure:
+  //    find the longest row vector in the candidatelist
+  //    orthogonalize the rest of the candidatelist to this vector
+  Eigen::MatrixXd candidatelist2(candidatelist); //local copy we will orthogonalize
+  std::vector<bool> design_flag(candidatelist2.rows(), false); //indicates that a candidate row has been used in the design
+  Eigen::VectorXi design_rows(nTrials);  //return value
+
+  double tolerance = 1e-8;
+  const int p = candidatelist2.cols();
+  for (int i = 0; i < p; i++) {
+    int nextrow = longest_row(candidatelist2, design_flag);
+    double nextrow_length = candidatelist2.row(nextrow).norm();
+    if (i == 0) {
+      tolerance = tolerance * nextrow_length; //scale tolerance to candidate list's longest vector
+    }
+    if (nextrow_length < tolerance) {
+      return Eigen::VectorXi::Zero(nTrials, 1); //rank-deficient candidate list, return error state
+    }
+    design_flag[nextrow] = true;
+    design_rows[i] = nextrow;
+    if (i != (p-1)) {
+      orthogonalize_input(candidatelist2, nextrow, design_flag);
+    }
+  }
+  //Then fill in the design with N - p randomly chosen rows from the candidatelist
+  Eigen::VectorXi random_indices = sample_replace(nTrials, nTrials);
+  for (int i = p; i < nTrials; i++) {
+    design_rows(i) = random_indices(i);
+  }
+
+  return design_rows;
+}
+

--- a/src/nullify_alg.h
+++ b/src/nullify_alg.h
@@ -1,98 +1,11 @@
 #include <RcppEigen.h>
 
-Eigen::VectorXi sample_replace(int max_value, int size) {
-  Eigen::VectorXi index(size);
-  for (int i = 0; i < size; i++) {
-    index(i) = max_value * unif_rand();
-  }
-  return(index);
-}
+Eigen::VectorXi sample_replace(int max_value, int size);
 
-//sample without replacement
-Eigen::VectorXi sample_noreplace(int max_value, int size) {
-  if(size > max_value) {
-    throw std::range_error("argument `size` cannot be greater than `max_value` when sampling without replacment");
-  }
-  int i, j;
-  Eigen::VectorXi index(size);
-  Eigen::VectorXi sub(max_value);
-  for (i = 0; i < max_value; i++) {
-    sub(i) = i;
-  }
-  for (i = 0; i < size; i++) {
-    j = max_value * unif_rand();
-    index(i) = sub(j);
-    sub(j) = sub(--max_value);
-  }
-  return(index);
-}
+Eigen::VectorXi sample_noreplace(int max_value, int size);
 
-int longest_row(const Eigen::MatrixXd& V, const std::vector<bool>& rows_used) {
-  //Return the index of the longest unused row in V
-  double longest = -1;
-  int index = 0;
-  for (int i = 0; i < V.rows(); i++) {
-    if (!rows_used[i]) {
-      double this_len = V.row(i).dot(V.row(i));
-      if (this_len > longest) {
-        longest = this_len;
-        index = i;
-      }
-    }
-  }
-  return index;
-}
+int longest_row(const Eigen::MatrixXd& V, const std::vector<bool>& rows_used);
 
+void orthogonalize_input(Eigen::MatrixXd& X, int basis_row, const std::vector<bool>& rows_used);
 
-void orthogonalize_input(Eigen::MatrixXd& X, int basis_row, const std::vector<bool>& rows_used) {
-  //Gram-Schmidt orthogonalize <X> - in place - with respect to its rownumber <basis_row>
-  //Only unused rows (as indicated by <rows_used>) are considered.
-  double basis_norm = X.row(basis_row).dot(X.row(basis_row));
-  for (int i = 0; i < X.rows(); i++) {
-    if (!rows_used[i]) {
-      double dotprod = X.row(i).dot(X.row(basis_row));
-      X.row(i) -= X.row(basis_row)*dotprod/basis_norm;
-    }
-  }
-}
-
-
-Eigen::VectorXi orthogonal_initial(const Eigen::MatrixXd& candidatelist, int nTrials) {
-  //Construct a nonsingular design matrix from candidatelist using the nullify procedure
-  //Returns a vector of rownumbers indicating which runs from candidatelist to use
-  //These rownumbers are not shuffled; you must do that yourself if randomizing the order is important
-  //If we cannot find a nonsingular design, returns a vector of zeros.
-
-  //First, find the p rows that come from the nullify procedure:
-  //    find the longest row vector in the candidatelist
-  //    orthogonalize the rest of the candidatelist to this vector
-  Eigen::MatrixXd candidatelist2(candidatelist); //local copy we will orthogonalize
-  std::vector<bool> design_flag(candidatelist2.rows(), false); //indicates that a candidate row has been used in the design
-  Eigen::VectorXi design_rows(nTrials);  //return value
-
-  double tolerance = 1e-8;
-  const int p = candidatelist2.cols();
-  for (int i = 0; i < p; i++) {
-    int nextrow = longest_row(candidatelist2, design_flag);
-    double nextrow_length = candidatelist2.row(nextrow).norm();
-    if (i == 0) {
-      tolerance = tolerance * nextrow_length; //scale tolerance to candidate list's longest vector
-    }
-    if (nextrow_length < tolerance) {
-      return Eigen::VectorXi::Zero(nTrials, 1); //rank-deficient candidate list, return error state
-    }
-    design_flag[nextrow] = true;
-    design_rows[i] = nextrow;
-    if (i != (p-1)) {
-      orthogonalize_input(candidatelist2, nextrow, design_flag);
-    }
-  }
-  //Then fill in the design with N - p randomly chosen rows from the candidatelist
-  Eigen::VectorXi random_indices = sample_replace(nTrials, nTrials);
-  for (int i = p; i < nTrials; i++) {
-    design_rows(i) = random_indices(i);
-  }
-
-  return design_rows;
-}
-
+Eigen::VectorXi orthogonal_initial(const Eigen::MatrixXd& candidatelist, int nTrials);

--- a/src/optimalityfunctions.cpp
+++ b/src/optimalityfunctions.cpp
@@ -1,0 +1,177 @@
+#include <RcppEigen.h>
+
+double calculateDOptimality(const Eigen::MatrixXd& currentDesign) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
+  return(XtX.partialPivLu().determinant());  //works without partialPivLu()
+}
+
+double calculateDOptimalityLog(const Eigen::MatrixXd& currentDesign) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
+  return(XtX.llt().matrixL().toDenseMatrix().diagonal().array().log().sum());
+}
+
+double calculateIOptimality(const Eigen::MatrixXd& currentV, const Eigen::MatrixXd& momentsMatrix) {
+  return((currentV * momentsMatrix).trace());
+}
+
+
+double calculateGOptimality(const Eigen::MatrixXd& currentV, const Eigen::MatrixXd& currentDesign) {
+  Eigen::MatrixXd results = currentDesign*currentV*currentDesign.transpose();
+  return(results.diagonal().maxCoeff());
+}
+
+double calculateTOptimality(const Eigen::MatrixXd& currentDesign) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
+  return(XtX.trace());
+}
+
+double calculateEOptimality(const Eigen::MatrixXd& currentDesign) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigensolver(XtX);
+  return(eigensolver.eigenvalues().minCoeff());
+}
+
+double calculateAOptimality(const Eigen::MatrixXd& currentV) {
+  return(currentV.trace());
+}
+
+double calculateAliasTraceSlow(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& aliasMatrix) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
+  Eigen::MatrixXd A = XtX.llt().solve(currentDesign.transpose())*aliasMatrix;
+  return((A.transpose() * A).trace());
+}
+
+double calculateAliasTrace(const Eigen::MatrixXd& currentV,
+                           const Eigen::MatrixXd& currentDesign,
+                           const Eigen::MatrixXd& aliasMatrix) {
+  Eigen::MatrixXd A = currentV*currentDesign.transpose()*aliasMatrix;
+  return((A.transpose() * A).trace());
+}
+
+double calculateDEff(const Eigen::MatrixXd& currentDesign, double numbercols, double numberrows) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
+  return(pow(XtX.partialPivLu().determinant(), 1/numbercols) / numberrows);
+}
+
+double calculateDEffLog(const Eigen::MatrixXd& currentDesign, double numbercols, double numberrows) {
+  return(pow(exp(calculateDOptimalityLog(currentDesign)), 1/numbercols) / numberrows);
+}
+
+double calculateDEffNN(const Eigen::MatrixXd& currentDesign, double numbercols) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
+  return(pow(XtX.partialPivLu().determinant(), 1.0/numbercols));
+}
+
+bool isSingular(const Eigen::MatrixXd& currentDesign) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
+  return(!XtX.colPivHouseholderQr().isInvertible());
+}
+
+double calculateCustomOptimality(const Eigen::MatrixXd& currentDesign, Rcpp::Function customOpt) {
+  return Rcpp::as<double>(customOpt(Rcpp::Named("currentDesign", currentDesign)));
+}
+
+void rankUpdate(Eigen::MatrixXd& vinv, const Eigen::VectorXd& pointold, const Eigen::VectorXd& pointnew,
+                const Eigen::MatrixXd& identity,
+                Eigen::MatrixXd& f1, Eigen::MatrixXd& f2,Eigen::MatrixXd& f2vinv) {
+  f1.col(0) = pointnew; f1.col(1) = -pointold;
+  f2.col(0) = pointnew; f2.col(1) = pointold;
+  f2vinv = f2.transpose()*vinv;
+  Eigen::MatrixXd tmp = vinv - vinv * f1 * (identity + f2vinv*f1).householderQr().solve(f2vinv);
+  vinv = tmp;
+}
+
+Eigen::MatrixXd rankUpdateValue(Eigen::MatrixXd& vinv, const Eigen::VectorXd& pointold, const Eigen::VectorXd& pointnew,
+                                const Eigen::MatrixXd& identity,
+                                Eigen::MatrixXd& f1, Eigen::MatrixXd& f2,Eigen::MatrixXd& f2vinv) {
+  f1.col(0) = pointnew; f1.col(1) = -pointold;
+  f2.col(0) = pointnew; f2.col(1) = pointold;
+  f2vinv = f2.transpose()*vinv;
+  Eigen::MatrixXd tmp = vinv - vinv * f1 * (identity + f2vinv*f1).householderQr().solve(f2vinv);
+  return(tmp);
+}
+
+void search_candidate_set(const Eigen::MatrixXd& V, const Eigen::MatrixXd& candidatelist_trans,
+                          const Eigen::VectorXd& designrow,
+                          double xVx, int& entryy, bool& found, double& del) {
+  Eigen::VectorXd yV(candidatelist_trans.rows());
+  double newdel = 0;
+  int ncols = candidatelist_trans.cols();
+  for (int j = 0; j < ncols; j++) {
+    yV = V * candidatelist_trans.col(j);
+    newdel = yV.dot(candidatelist_trans.col(j))*(1 - xVx) - xVx + pow(yV.dot(designrow),2);
+    if(newdel > del) {
+      found = true;
+      entryy = j;
+      del = newdel;
+    }
+  }
+}
+
+//**********************************************************
+//Everything below is for generating blocked optimal designs
+//**********************************************************
+
+double calculateBlockedDOptimality(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& gls) {
+  return((currentDesign.transpose()*gls*currentDesign).partialPivLu().determinant());
+}
+
+double calculateBlockedDOptimalityLog(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& gls) {
+  Eigen::MatrixXd XtX = (currentDesign.transpose()*gls*currentDesign);
+  return(exp(XtX.llt().matrixL().toDenseMatrix().diagonal().array().log().sum()));
+}
+
+double calculateBlockedIOptimality(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& momentsMatrix,const Eigen::MatrixXd& gls) {
+  return(((currentDesign.transpose()*gls*currentDesign).llt().solve(momentsMatrix)).trace());
+}
+
+double calculateBlockedAOptimality(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls) {
+  return((currentDesign.transpose()*gls*currentDesign).partialPivLu().inverse().trace());
+}
+
+double calculateBlockedAliasTrace(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& aliasMatrix,const Eigen::MatrixXd& gls) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*gls*currentDesign;
+  Eigen::MatrixXd A = XtX.llt().solve(currentDesign.transpose()*aliasMatrix);
+  return((A.transpose() * A).trace());
+}
+
+double calculateBlockedGOptimality(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& gls) {
+  Eigen::MatrixXd results = currentDesign*(currentDesign.transpose()*gls*currentDesign).partialPivLu().solve(currentDesign.transpose())*gls;
+  return(results.diagonal().maxCoeff());
+}
+
+double calculateBlockedTOptimality(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls) {
+  return((currentDesign.transpose()*gls*currentDesign).trace());
+}
+
+double calculateBlockedEOptimality(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*gls*currentDesign;
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigensolver(XtX);
+  return(eigensolver.eigenvalues().minCoeff());
+}
+
+double calculateBlockedDEff(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*gls*currentDesign;
+  return(pow(XtX.partialPivLu().determinant(), 1/currentDesign.cols()) / currentDesign.rows());
+}
+
+double calculateBlockedDEffNN(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*gls*currentDesign;
+  return(pow(XtX.partialPivLu().determinant(), 1.0/currentDesign.cols()));
+}
+
+double calculateBlockedAliasTracePseudoInv(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& aliasMatrix,const Eigen::MatrixXd& gls) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*gls*currentDesign;
+  Eigen::MatrixXd A = XtX.partialPivLu().solve(currentDesign.transpose()*aliasMatrix);
+  return((A.transpose() * A).trace());
+}
+
+bool isSingularBlocked(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls) {
+  Eigen::MatrixXd XtX = currentDesign.transpose()*gls*currentDesign;
+  return(!XtX.colPivHouseholderQr().isInvertible());
+}
+
+double calculateBlockedCustomOptimality(const Eigen::MatrixXd& currentDesign, Rcpp::Function customBlockedOpt, const Eigen::MatrixXd& gls) {
+  return Rcpp::as<double>(customBlockedOpt(Rcpp::Named("currentDesign", currentDesign),Rcpp::Named("vInv", gls)));
+}
+

--- a/src/optimalityfunctions.h
+++ b/src/optimalityfunctions.h
@@ -1,177 +1,74 @@
 #include <RcppEigen.h>
 
-double calculateDOptimality(const Eigen::MatrixXd& currentDesign) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
-  return(XtX.partialPivLu().determinant());  //works without partialPivLu()
-}
+double calculateDOptimality(const Eigen::MatrixXd& currentDesign);
 
-double calculateDOptimalityLog(const Eigen::MatrixXd& currentDesign) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
-  return(XtX.llt().matrixL().toDenseMatrix().diagonal().array().log().sum());
-}
-
-double calculateIOptimality(const Eigen::MatrixXd& currentV, const Eigen::MatrixXd& momentsMatrix) {
-  return((currentV * momentsMatrix).trace());
-}
+double calculateDOptimalityLog(const Eigen::MatrixXd& currentDesign);
 
 
-double calculateGOptimality(const Eigen::MatrixXd& currentV, const Eigen::MatrixXd& currentDesign) {
-  Eigen::MatrixXd results = currentDesign*currentV*currentDesign.transpose();
-  return(results.diagonal().maxCoeff());
-}
+double calculateIOptimality(const Eigen::MatrixXd& currentV, const Eigen::MatrixXd& momentsMatrix);
 
-double calculateTOptimality(const Eigen::MatrixXd& currentDesign) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
-  return(XtX.trace());
-}
+double calculateGOptimality(const Eigen::MatrixXd& currentV, const Eigen::MatrixXd& currentDesign);
 
-double calculateEOptimality(const Eigen::MatrixXd& currentDesign) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
-  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigensolver(XtX);
-  return(eigensolver.eigenvalues().minCoeff());
-}
+double calculateTOptimality(const Eigen::MatrixXd& currentDesign);
 
-double calculateAOptimality(const Eigen::MatrixXd& currentV) {
-  return(currentV.trace());
-}
+double calculateEOptimality(const Eigen::MatrixXd& currentDesign);
 
-double calculateAliasTraceSlow(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& aliasMatrix) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
-  Eigen::MatrixXd A = XtX.llt().solve(currentDesign.transpose())*aliasMatrix;
-  return((A.transpose() * A).trace());
-}
+double calculateAOptimality(const Eigen::MatrixXd& currentV);
+
+double calculateAliasTraceSlow(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& aliasMatrix);
 
 double calculateAliasTrace(const Eigen::MatrixXd& currentV,
                            const Eigen::MatrixXd& currentDesign,
-                           const Eigen::MatrixXd& aliasMatrix) {
-  Eigen::MatrixXd A = currentV*currentDesign.transpose()*aliasMatrix;
-  return((A.transpose() * A).trace());
-}
+                           const Eigen::MatrixXd& aliasMatrix);
 
-double calculateDEff(const Eigen::MatrixXd& currentDesign, double numbercols, double numberrows) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
-  return(pow(XtX.partialPivLu().determinant(), 1/numbercols) / numberrows);
-}
+double calculateDEff(const Eigen::MatrixXd& currentDesign, double numbercols, double numberrows);
 
-double calculateDEffLog(const Eigen::MatrixXd& currentDesign, double numbercols, double numberrows) {
-  return(pow(exp(calculateDOptimalityLog(currentDesign)), 1/numbercols) / numberrows);
-}
+double calculateDEffLog(const Eigen::MatrixXd& currentDesign, double numbercols, double numberrows);
 
-double calculateDEffNN(const Eigen::MatrixXd& currentDesign, double numbercols) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
-  return(pow(XtX.partialPivLu().determinant(), 1.0/numbercols));
-}
+double calculateDEffNN(const Eigen::MatrixXd& currentDesign, double numbercols);
 
-bool isSingular(const Eigen::MatrixXd& currentDesign) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
-  return(!XtX.colPivHouseholderQr().isInvertible());
-}
+bool isSingular(const Eigen::MatrixXd& currentDesign);
 
-double calculateCustomOptimality(const Eigen::MatrixXd& currentDesign, Rcpp::Function customOpt) {
-  return Rcpp::as<double>(customOpt(Rcpp::Named("currentDesign", currentDesign)));
-}
+double calculateCustomOptimality(const Eigen::MatrixXd& currentDesign, Rcpp::Function customOpt);
 
 void rankUpdate(Eigen::MatrixXd& vinv, const Eigen::VectorXd& pointold, const Eigen::VectorXd& pointnew,
                 const Eigen::MatrixXd& identity,
-                Eigen::MatrixXd& f1, Eigen::MatrixXd& f2,Eigen::MatrixXd& f2vinv) {
-  f1.col(0) = pointnew; f1.col(1) = -pointold;
-  f2.col(0) = pointnew; f2.col(1) = pointold;
-  f2vinv = f2.transpose()*vinv;
-  Eigen::MatrixXd tmp = vinv - vinv * f1 * (identity + f2vinv*f1).householderQr().solve(f2vinv);
-  vinv = tmp;
-}
+                Eigen::MatrixXd& f1, Eigen::MatrixXd& f2,Eigen::MatrixXd& f2vinv);
 
 Eigen::MatrixXd rankUpdateValue(Eigen::MatrixXd& vinv, const Eigen::VectorXd& pointold, const Eigen::VectorXd& pointnew,
                                 const Eigen::MatrixXd& identity,
-                                Eigen::MatrixXd& f1, Eigen::MatrixXd& f2,Eigen::MatrixXd& f2vinv) {
-  f1.col(0) = pointnew; f1.col(1) = -pointold;
-  f2.col(0) = pointnew; f2.col(1) = pointold;
-  f2vinv = f2.transpose()*vinv;
-  Eigen::MatrixXd tmp = vinv - vinv * f1 * (identity + f2vinv*f1).householderQr().solve(f2vinv);
-  return(tmp);
-}
+                                Eigen::MatrixXd& f1, Eigen::MatrixXd& f2,Eigen::MatrixXd& f2vinv);
 
 void search_candidate_set(const Eigen::MatrixXd& V, const Eigen::MatrixXd& candidatelist_trans,
                           const Eigen::VectorXd& designrow,
-                          double xVx, int& entryy, bool& found, double& del) {
-  Eigen::VectorXd yV(candidatelist_trans.rows());
-  double newdel = 0;
-  int ncols = candidatelist_trans.cols();
-  for (int j = 0; j < ncols; j++) {
-    yV = V * candidatelist_trans.col(j);
-    newdel = yV.dot(candidatelist_trans.col(j))*(1 - xVx) - xVx + pow(yV.dot(designrow),2);
-    if(newdel > del) {
-      found = true;
-      entryy = j;
-      del = newdel;
-    }
-  }
-}
+                          double xVx, int& entryy, bool& found, double& del);
 
 //**********************************************************
 //Everything below is for generating blocked optimal designs
 //**********************************************************
 
-double calculateBlockedDOptimality(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& gls) {
-  return((currentDesign.transpose()*gls*currentDesign).partialPivLu().determinant());
-}
+double calculateBlockedDOptimality(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& gls);
 
-double calculateBlockedDOptimalityLog(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& gls) {
-  Eigen::MatrixXd XtX = (currentDesign.transpose()*gls*currentDesign);
-  return(exp(XtX.llt().matrixL().toDenseMatrix().diagonal().array().log().sum()));
-}
+double calculateBlockedDOptimalityLog(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& gls);
 
-double calculateBlockedIOptimality(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& momentsMatrix,const Eigen::MatrixXd& gls) {
-  return(((currentDesign.transpose()*gls*currentDesign).llt().solve(momentsMatrix)).trace());
-}
+double calculateBlockedIOptimality(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& momentsMatrix,const Eigen::MatrixXd& gls);
 
-double calculateBlockedAOptimality(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls) {
-  return((currentDesign.transpose()*gls*currentDesign).partialPivLu().inverse().trace());
-}
+double calculateBlockedAOptimality(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls);
 
-double calculateBlockedAliasTrace(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& aliasMatrix,const Eigen::MatrixXd& gls) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*gls*currentDesign;
-  Eigen::MatrixXd A = XtX.llt().solve(currentDesign.transpose()*aliasMatrix);
-  return((A.transpose() * A).trace());
-}
+double calculateBlockedAliasTrace(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& aliasMatrix,const Eigen::MatrixXd& gls);
 
-double calculateBlockedGOptimality(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& gls) {
-  Eigen::MatrixXd results = currentDesign*(currentDesign.transpose()*gls*currentDesign).partialPivLu().solve(currentDesign.transpose())*gls;
-  return(results.diagonal().maxCoeff());
-}
+double calculateBlockedGOptimality(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& gls);
 
-double calculateBlockedTOptimality(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls) {
-  return((currentDesign.transpose()*gls*currentDesign).trace());
-}
+double calculateBlockedTOptimality(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls);
 
-double calculateBlockedEOptimality(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*gls*currentDesign;
-  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigensolver(XtX);
-  return(eigensolver.eigenvalues().minCoeff());
-}
+double calculateBlockedEOptimality(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls);
 
-double calculateBlockedDEff(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*gls*currentDesign;
-  return(pow(XtX.partialPivLu().determinant(), 1/currentDesign.cols()) / currentDesign.rows());
-}
+double calculateBlockedDEff(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls);
 
-double calculateBlockedDEffNN(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*gls*currentDesign;
-  return(pow(XtX.partialPivLu().determinant(), 1.0/currentDesign.cols()));
-}
+double calculateBlockedDEffNN(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls);
 
-double calculateBlockedAliasTracePseudoInv(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& aliasMatrix,const Eigen::MatrixXd& gls) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*gls*currentDesign;
-  Eigen::MatrixXd A = XtX.partialPivLu().solve(currentDesign.transpose()*aliasMatrix);
-  return((A.transpose() * A).trace());
-}
+double calculateBlockedAliasTracePseudoInv(const Eigen::MatrixXd& currentDesign, const Eigen::MatrixXd& aliasMatrix,const Eigen::MatrixXd& gls);
 
-bool isSingularBlocked(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls) {
-  Eigen::MatrixXd XtX = currentDesign.transpose()*gls*currentDesign;
-  return(!XtX.colPivHouseholderQr().isInvertible());
-}
+bool isSingularBlocked(const Eigen::MatrixXd& currentDesign,const Eigen::MatrixXd& gls);
 
-double calculateBlockedCustomOptimality(const Eigen::MatrixXd& currentDesign, Rcpp::Function customBlockedOpt, const Eigen::MatrixXd& gls) {
-  return Rcpp::as<double>(customBlockedOpt(Rcpp::Named("currentDesign", currentDesign),Rcpp::Named("vInv", gls)));
-}
-
+double calculateBlockedCustomOptimality(const Eigen::MatrixXd& currentDesign, Rcpp::Function customBlockedOpt, const Eigen::MatrixXd& gls);


### PR DESCRIPTION
Header files should only have function declarations. This change converts the header files to function declarations and moves the function definitions to separate cpp files.