### PR TITLE
more numerically stable DOptimalityLog

### DIFF
--- a/R/eval_design.R
+++ b/R/eval_design.R
@@ -414,7 +414,7 @@ eval_design = function(design, model = NULL, alpha = 0.05,
     if(!is.infinite(deffic)) {
       attr(results, "D") =  100 * DOptimality(modelmatrix_cor) ^ (1 / ncol(modelmatrix_cor)) / nrow(modelmatrix_cor)
     } else {
-      attr(results, "D") =  100 * DOptimalityLog(modelmatrix_cor) ^ (1 / ncol(modelmatrix_cor)) / nrow(modelmatrix_cor)
+      attr(results, "D") =  100 * exp(DOptimalityLog(modelmatrix_cor) / ncol(modelmatrix_cor)) / nrow(modelmatrix_cor)
     }
   } else {
     attr(results, "z.matrix.list") = zlist

--- a/R/eval_design_mc.R
+++ b/R/eval_design_mc.R
@@ -797,7 +797,7 @@ eval_design_mc = function(design, model = NULL, alpha = 0.05,
     if(!is.infinite(deffic)) {
       attr(retval, "D") =  100 * DOptimality(modelmatrix_cor) ^ (1 / ncol(modelmatrix_cor)) / nrow(modelmatrix_cor)
     } else {
-      attr(retval, "D") =  100 * DOptimalityLog(modelmatrix_cor) ^ (1 / ncol(modelmatrix_cor)) / nrow(modelmatrix_cor)
+      attr(retval, "D") =  100 * exp(DOptimalityLog(modelmatrix_cor) / ncol(modelmatrix_cor)) / nrow(modelmatrix_cor)
     }
   } else {
     attr(retval, "variance.matrix") = V

--- a/R/gen_design.R
+++ b/R/gen_design.R
@@ -1239,7 +1239,7 @@ gen_design = function(candidateset, model, trials,
   if(!is.infinite(deffic)) {
     attr(design, "D") =  100 * DOptimality(designmm) ^ (1 / ncol(designmm)) / nrow(designmm)
   } else {
-    attr(design, "D") =  100 * DOptimalityLog(designmm) ^ (1 / ncol(designmm)) / nrow(designmm)
+    attr(design, "D") =  100 * exp(DOptimalityLog(designmm) / ncol(designmm)) / nrow(designmm)
   }
   attr(design, "A") = tryCatch({AOptimality(designmm)}, error = function(e) {})
   attr(design, "model.matrix") = designmm

--- a/src/exported_optimality.cpp
+++ b/src/exported_optimality.cpp
@@ -12,7 +12,7 @@ double DOptimality(const Eigen::MatrixXd& currentDesign) {
 // [[Rcpp::export]]
 double DOptimalityLog(const Eigen::MatrixXd& currentDesign) {
   Eigen::MatrixXd XtX = currentDesign.transpose()*currentDesign;
-  return(exp(XtX.llt().matrixL().toDenseMatrix().diagonal().array().log().sum()));
+  return(XtX.llt().matrixL().toDenseMatrix().diagonal().array().log().sum());
 }
 
 // [[Rcpp::export]]

--- a/src/genOptimalDesign.cpp
+++ b/src/genOptimalDesign.cpp
@@ -119,10 +119,7 @@ List genOptimalDesign(Eigen::MatrixXd initialdesign, const Eigen::MatrixXd& cand
   Eigen::MatrixXd V = (initialdesign.transpose()*initialdesign).partialPivLu().inverse();
   //Generate a D-optimal design
   if(condition == "D" || condition == "G") {
-    newOptimum = calculateDOptimality(initialdesign);
-    if(std::isinf(newOptimum)) {
-      newOptimum = exp(calculateDOptimalityLog(initialdesign));
-    }
+    newOptimum = 1.0;
     priorOptimum = newOptimum/2;
 
     while((newOptimum - priorOptimum)/priorOptimum > minDelta) {

--- a/src/optimalityfunctions.cpp
+++ b/src/optimalityfunctions.cpp
@@ -54,7 +54,7 @@ double calculateDEff(const Eigen::MatrixXd& currentDesign, double numbercols, do
 }
 
 double calculateDEffLog(const Eigen::MatrixXd& currentDesign, double numbercols, double numberrows) {
-  return(pow(exp(calculateDOptimalityLog(currentDesign)), 1/numbercols) / numberrows);
+  return(exp(calculateDOptimalityLog(currentDesign)/numbercols) / numberrows);
 }
 
 double calculateDEffNN(const Eigen::MatrixXd& currentDesign, double numbercols) {


### PR DESCRIPTION
Taking exp() out of DOptimalityLog - so that the caller has to explicitly call exp() on the result of DOptimalityLog - allows a more numerically stable calculation of DOptimality.