### PR TITLE
Cast to int for Eigen 3.4.0

### DIFF
--- a/src/genSplitPlotOptimalDesign.cpp
+++ b/src/genSplitPlotOptimalDesign.cpp
@@ -188,9 +188,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  temp(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  temp(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= temp(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= temp(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               temp(i,blockedCols+designCols + k) = interactiontempval;
             }
@@ -223,9 +223,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               combinedDesign(i,blockedCols+designCols + k) = interactiontempval;
             }
@@ -264,9 +264,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
             //Calculate interaction terms for sub-whole plot interactions
             if(interstrata) {
               for(int k = 0; k < numberinteractions; k++) {
-                interactiontempval =  temp(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+                interactiontempval =  temp(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
                 for(int kk = 1; kk < orderinteraction(k); kk++) {
-                  interactiontempval *= temp(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                  interactiontempval *= temp(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
                 }
                 temp(i,blockedCols+designCols + k) = interactiontempval;
               }
@@ -297,9 +297,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               combinedDesign(i,blockedCols+designCols + k) = interactiontempval;
             }
@@ -339,9 +339,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
             //Calculate interaction terms for sub-whole plot interactions
             if(interstrata) {
               for(int k = 0; k < numberinteractions; k++) {
-                interactiontempval =  temp(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+                interactiontempval =  temp(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
                 for(int kk = 1; kk < orderinteraction(k); kk++) {
-                  interactiontempval *= temp(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                  interactiontempval *= temp(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
                 }
                 temp(i,blockedCols+designCols + k) = interactiontempval;
               }
@@ -372,9 +372,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               combinedDesign(i,blockedCols+designCols + k) = interactiontempval;
             }
@@ -407,9 +407,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  temp(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  temp(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= temp(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= temp(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               temp(i,blockedCols+designCols + k) = interactiontempval;
             }
@@ -440,9 +440,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               combinedDesign(i,blockedCols+designCols + k) = interactiontempval;
             }
@@ -477,9 +477,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  temp(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  temp(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= temp(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= temp(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               temp(i,blockedCols+designCols + k) = interactiontempval;
             }
@@ -514,9 +514,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               combinedDesign(i,blockedCols+designCols + k) = interactiontempval;
             }
@@ -549,9 +549,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  temp(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  temp(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= temp(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= temp(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               temp(i,blockedCols+designCols + k) = interactiontempval;
             }
@@ -586,9 +586,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               combinedDesign(i,blockedCols+designCols + k) = interactiontempval;
             }
@@ -625,9 +625,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  temp(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  temp(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= temp(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= temp(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               temp(i,blockedCols+designCols + k) = interactiontempval;
             }
@@ -657,11 +657,11 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
-              interactiontempvalalias = combinedAliasDesign(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
+              interactiontempvalalias = combinedAliasDesign(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
-                interactiontempvalalias *= combinedAliasDesign(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
+                interactiontempvalalias *= combinedAliasDesign(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               combinedDesign(i,blockedCols+designCols + k) = interactiontempval;
               combinedAliasDesign(i,blockedCols+designCols + k) = interactiontempval;
@@ -718,11 +718,11 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
               //Calculate interaction terms for sub-whole plot interactions
               if(interstrata) {
                 for(int k = 0; k < numberinteractions; k++) {
-                  interactiontempval =  temp(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
-                  interactiontempvalalias = tempalias(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+                  interactiontempval =  temp(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
+                  interactiontempvalalias = tempalias(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
                   for(int kk = 1; kk < orderinteraction(k); kk++) {
-                    interactiontempval *= temp(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
-                    interactiontempvalalias *= tempalias(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                    interactiontempval *= temp(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
+                    interactiontempvalalias *= tempalias(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
                   }
                   temp(i,blockedCols+designCols + k) = interactiontempval;
                   tempalias(i,blockedCols+designColsAlias + k) = interactiontempvalalias;
@@ -758,11 +758,11 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
             //Calculate interaction terms for sub-whole plot interactions
             if(interstrata) {
               for(int k = 0; k < numberinteractions; k++) {
-                interactiontempval =  combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
-                interactiontempvalalias = combinedAliasDesign(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+                interactiontempval =  combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
+                interactiontempvalalias = combinedAliasDesign(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
                 for(int kk = 1; kk < orderinteraction(k); kk++) {
-                  interactiontempval *= combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
-                  interactiontempvalalias *= combinedAliasDesign(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                  interactiontempval *= combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
+                  interactiontempvalalias *= combinedAliasDesign(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
                 }
                 combinedDesign(i,blockedCols+designCols + k) = interactiontempval;
                 combinedAliasDesign(i,blockedCols+designCols + k) = interactiontempval;
@@ -812,9 +812,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  temp(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  temp(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= temp(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= temp(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               temp(i,blockedCols+designCols + k) = interactiontempval;
             }
@@ -849,9 +849,9 @@ List genSplitPlotOptimalDesign(Eigen::MatrixXd initialdesign, Eigen::MatrixXd ca
           //Calculate interaction terms for sub-whole plot interactions
           if(interstrata) {
             for(int k = 0; k < numberinteractions; k++) {
-              interactiontempval =  combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(0)-1);
+              interactiontempval =  combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(0)-1);
               for(int kk = 1; kk < orderinteraction(k); kk++) {
-                interactiontempval *= combinedDesign(i,as<Eigen::VectorXd>(interactions[k])(kk)-1);
+                interactiontempval *= combinedDesign(i,as<Eigen::VectorXi>(interactions[k])(kk)-1);
               }
               combinedDesign(i,blockedCols+designCols + k) = interactiontempval;
             }


### PR DESCRIPTION
Dear Tyler, dear skpr team,

Eigen 3.4.0 was released earlier in the year, and I have been asked to update RcppEigen to it. As documented [in this issue at its GitHub repo](https://github.com/RcppCore/RcppEigen/issues/103), there are about nine packages that built at CRAN under the previous release, but not with the Eigen 3.4.0 changes in the release candidate package -- which can be installed via

    install.packages("RcppEigen", repo="https://RcppCore.github.io/drat")

For skpr, the change is (mostly) fairly simple. Apparently Eigen 3.4.0 dislikes `double` variables as matrix or vector indices so in spots where you cast `MatrixXd` we now use `MatrixXi`. With that simple changes in this PR, the package installs for me. The RcppEigen pre-release from the drat repo listed above will let you test this.

It would be helpful for RcppEigen if you could apply the patch and release an updated version so that RcppEigen could be upgraded to a version with Eigen 3.4.0.

Let me know if you have any question, and please do not hesitate to reply and ask.

Cheers, Dirk (who looks after RcppEigen as a care-taker...)