### PR TITLE
eval_design_mc, specify `method` as a function

### DIFF
--- a/R/eval_design_mc.R
+++ b/R/eval_design_mc.R
@@ -217,7 +217,7 @@ eval_design_mc = function(design, model = NULL, alpha = 0.05,
     if(!(length(find.package("mbest", quiet = TRUE)) > 0)) {
       stop("Firth correction requires installation of the `mbest` package.")
     }
-    method = "firthglm.fit"
+    method = mbest::firthglm.fit
   }
   if(missing(design)) {
     stop("No design detected in arguments.")


### PR DESCRIPTION
this change allows the user to do a firth regression without loading the mbest package first.

Without this change, the firth code wouldn't run if parallel = FALSE. But it did run if parallel = TRUE, thanks to the magic of dopar.