### PR TITLE
Allow advanced "cores" options for makeCluster

### DIFF
--- a/R/gen_design.R
+++ b/R/gen_design.R
@@ -901,11 +901,12 @@ gen_design = function(candidateset, model, trials,
       } else {
         numbercores = options("cores")[[1]]
       }
+      cl = parallel::makeCluster(numbercores)
+      numbercores = length(cl)
       if(timer) {
         pb = progress::progress_bar$new(format = sprintf("  Searching (%d cores) [:bar] :percent ETA: :eta", numbercores),
                                         total = repeats, clear = TRUE, width= 60)
       }
-      cl = parallel::makeCluster(numbercores)
       tryCatch({
         doParallel::registerDoParallel(cl)
         number_updates = max(c(min(c(repeats/(2*numbercores),100)),1))
@@ -1034,6 +1035,7 @@ gen_design = function(candidateset, model, trials,
                                         total = repeats, clear = TRUE, width= 60)
       }
       cl = parallel::makeCluster(numbercores)
+      numbercores = length(cl)
       tryCatch({
         doParallel::registerDoParallel(cl)
         number_updates = max(c(min(c(repeats/(2*numbercores),100)),1))

--- a/tests/testthat/testExampleCode.R
+++ b/tests/testthat/testExampleCode.R
@@ -421,7 +421,7 @@ test_that("eval_design_custom_mc example code runs without errors", {
 
   #testing parallel
 
-  options(cores = 2)
+  options(cores = c("localhost", "localhost"))
   basicdesign = expand.grid(a = c(-1, 1))
   design = gen_design(candidateset = basicdesign, model = ~a, trials = 100,
                       optimality = "D", repeats = 100)


### PR DESCRIPTION
`gen_design()` has a `parallel` argument which allows doing multi-processing on the localhost. This patch changes how the `cores` option is handled, to take full advantage of the capabilities of [makePSOCKcluster](https://www.rdocumentation.org/packages/parallel/versions/3.6.2/topics/makeCluster) which is used under the hood. This makes multi-processing on a multi-host cluster possible.

Examples:

```r
# 8 processes on the localhost
options(cores = 8)

# 3 processes on 3 different hosts
options(cores = c("localhost", "otherhost1", "otherhost2"))

# 3 processes on 3 different hosts with different user names
options(cores = list(
    list(host = "localhost"),
    list(host = "otherhost1", user = "user1"),
    list(host = "otherhost2", user = "user2")))
```