### PR TITLE
Fix degrees of freedom calculation

### DIFF
--- a/R/calculate_degrees_of_freedom.R
+++ b/R/calculate_degrees_of_freedom.R
@@ -88,11 +88,11 @@ calculate_degrees_of_freedom = function(
         if (length(layercols) > 0) {
           for (j in seq_len(length(layercols))) {
             if (
-              is.numeric(run_matrix_processed[, layercols[j], drop = FALSE])
+              is.numeric(run_matrix_processed[, layercols[j]])
             ) {
               mtemp = mtemp - 1
             } else {
-              cat_degrees = length(unique(run_matrix_processed[,
+              cat_degrees = nrow(unique(run_matrix_processed[,
                 layercols[j],
                 drop = FALSE
               ])) -
@@ -138,9 +138,9 @@ calculate_degrees_of_freedom = function(
             #e.g. two 3 level factors interacting = 1*(3-1)*(3-1) = 4 df total.
             temp_degrees = 1
             for (col_name in interaction_cols) {
-              if (!is.numeric(run_matrix_processed[, col_name, drop = FALSE])) {
+              if (!is.numeric(run_matrix_processed[, col_name])) {
                 temp_degrees = temp_degrees *
-                  (length(unique(run_matrix_processed[,
+                  (nrow(unique(run_matrix_processed[,
                     col_name,
                     drop = FALSE
                   ])) -
@@ -166,10 +166,10 @@ calculate_degrees_of_freedom = function(
     if (split_plot_structure) {
       if (length(layercols) > 0) {
         for (j in seq_len(length(layercols))) {
-          if (is.numeric(run_matrix_processed[, layercols[j], drop = FALSE])) {
+          if (is.numeric(run_matrix_processed[, layercols[j]])) {
             mtemp = mtemp - 1
           } else {
-            cat_degrees = length(unique(run_matrix_processed[,
+            cat_degrees = nrow(unique(run_matrix_processed[,
               layercols[j],
               drop = FALSE
             ])) -
@@ -193,11 +193,11 @@ calculate_degrees_of_freedom = function(
         if (length(layercols) > 0) {
           for (j in seq_len(length(layercols))) {
             if (
-              is.numeric(run_matrix_processed[, layercols[j], drop = FALSE])
+              is.numeric(run_matrix_processed[, layercols[j]])
             ) {
               mtemp = mtemp - 1
             } else {
-              cat_degrees = length(unique(run_matrix_processed[,
+              cat_degrees = nrow(unique(run_matrix_processed[,
                 layercols[j],
                 drop = FALSE
               ])) -
@@ -244,9 +244,9 @@ calculate_degrees_of_freedom = function(
           #e.g. two 3 level factors interacting = 1*(3-1)*(3-1) = 4 df total.
           temp_degrees = 1
           for (col_name in interaction_cols) {
-            if (!is.numeric(run_matrix_processed[, col_name, drop = FALSE])) {
+            if (!is.numeric(run_matrix_processed[, col_name])) {
               temp_degrees = temp_degrees *
-                (length(unique(run_matrix_processed[,
+                (nrow(unique(run_matrix_processed[,
                   col_name,
                   drop = FALSE
                 ])) -


### PR DESCRIPTION
Fixes a bug in the `calculate_degrees_of_freedom` function, introduced by commit 0eece6f.

That commit added `drop = FALSE` arguments to the data frame column selection, which forces the returned value to be a data frame. However, `is.numeric` and `length` don't behave the same with data frames, compared to vectors:
```
> df <- data.frame(one=1:10, two=11:20, three=21:30)
> df
   one two three
1    1  11    21
2    2  12    22
3    3  13    23
4    4  14    24
5    5  15    25
6    6  16    26
7    7  17    27
8    8  18    28
9    9  19    29
10  10  20    30
> is.numeric(df[,1,drop=FALSE])
[1] FALSE
> is.numeric(df[,1])
[1] TRUE
> length(df[,1,drop=FALSE])
[1] 1
> nrow(df[,1,drop=FALSE])
[1] 10
```

To test the behaviour, I used this blocked design:
```
run_processed_1 <- data.frame(
     n2l=c(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1),
     cat=c("dogs","marmosets","dogs","marmosets","cats","cats","dogs","marmosets","dogs","marmosets","dogs","cats","marmosets","dogs","cats","cats","cats","marmosets","marmosets","cats","cats","dogs","dogs","marmosets","cats","marmosets","dogs","dogs","dogs","marmosets","cats","marmosets"),
     n3l=c(0,-1,1,0,-1,1,-1,1,1,-1,-1,0,1,-1,-1,1,1,-1,1,0,-1,-1,1,-1,-1,0,0,1,-1,-1,1,1),
     row.names=c("1.1","1.2","1.3","1.4","1.5","1.6","1.7","1.8","2.9","2.10","2.11","2.12","2.13","2.14","2.15","2.16","3.17","3.18","3.19","3.20","3.21","3.22","3.23","3.24","4.25","4.26","4.27","4.28","4.29","4.30","4.31","4.32")
)

model_1 <- as.formula("~ n2l + cat + n3l + n2l:cat + n2l:n3l + cat:n3l + I(n3l^2)")
```

```
> run_processed_1
     n2l       cat n3l
1.1    1      dogs   0
1.2    1 marmosets  -1
1.3    1      dogs   1
1.4    1 marmosets   0
1.5    1      cats  -1
1.6    1      cats   1
1.7    1      dogs  -1
1.8    1 marmosets   1
2.9    1      dogs   1
2.10   1 marmosets  -1
2.11   1      dogs  -1
2.12   1      cats   0
2.13   1 marmosets   1
2.14   1      dogs  -1
2.15   1      cats  -1
2.16   1      cats   1
3.17  -1      cats   1
3.18  -1 marmosets  -1
3.19  -1 marmosets   1
3.20  -1      cats   0
3.21  -1      cats  -1
3.22  -1      dogs  -1
3.23  -1      dogs   1
3.24  -1 marmosets  -1
4.25  -1      cats  -1
4.26  -1 marmosets   0
4.27  -1      dogs   0
4.28  -1      dogs   1
4.29  -1      dogs  -1
4.30  -1 marmosets  -1
4.31  -1      cats   1
4.32  -1 marmosets   1
```

I then checked the output of `calculate_degrees_of_freedom(run_processed_1, FALSE, model_1, contr.sum)` for the commit before 0eece6f (d7381cd), for master, and for this PR:

### d7381cd
```
(Intercept)         n2l         cat         n3l    I(n3l^2)     n2l:cat 
          2           2          19          19          19          19 
    n2l:n3l     cat:n3l 
         19          19 
```

### master
```
(Intercept)         n2l         cat         n3l    I(n3l^2)     n2l:cat 
          3           3          28          28          28          28 
    n2l:n3l     cat:n3l 
         28          28 
```

### This PR
```
(Intercept)         n2l         cat         n3l    I(n3l^2)     n2l:cat 
          2           2          19          19          19          19 
    n2l:n3l     cat:n3l 
         19          19 
```