### PR TITLE
Fix `gen_momentsmatrix_constrained` errors

### DIFF
--- a/R/calculate_convex_hull_moment_matrix.R
+++ b/R/calculate_convex_hull_moment_matrix.R
@@ -154,7 +154,8 @@ gen_momentsmatrix_constrained = function(
       w[interp_ch$on_edge] = 0.5
     }
     # average subregion moment
-    Xsub_w = apply(Xsub, 2, \(x) x * sqrt(w))
+    w_mat = matrix(rep(w, ncol(Xsub)), ncol=ncol(Xsub))
+    Xsub_w = Xsub * sqrt(w_mat)
 
     M = crossprod(Xsub_w) / sum(w)
 
@@ -256,7 +257,8 @@ gen_momentsmatrix_constrained = function(
         w[interp_ch$on_edge] = 0.5
       }
       # average subregion moment
-      Xsub_w = apply(Xsub, 2, \(x) x * sqrt(w))
+      w_mat = matrix(rep(w, ncol(Xsub)), ncol=ncol(Xsub))
+      Xsub_w = Xsub * sqrt(w_mat)
 
       M_sub = crossprod(Xsub_w) / sum(w)
 


### PR DESCRIPTION
I was getting the following error when running `eval_design`: `Error in M_acc + vol * M_sub: non-conformable arrays`

I tracked this down to `gen_momentsmatrix_constrained`. For categorical columns, if there was a single instance of a particular combination, this error would be raised. This is due to `apply` simplifying 1 row matrices / data frames to vectors.

When applied to a data frame with more than 1 row:
```
> df <- data.frame(one=1:4, two=11:14, three=21:24)
> df
  one two three
1   1  11    21
2   2  12    22
3   3  13    23
4   4  14    24
> out <- apply(df, 2, \(x) x / 1:4)
> out
     one       two     three
[1,]   1 11.000000 21.000000
[2,]   1  6.000000 11.000000
[3,]   1  4.333333  7.666667
[4,]   1  3.500000  6.000000
> class(out)
[1] "matrix" "array" 
```

When applied to a data frame with 1 row:
```
> df <- data.frame(one=1, two=11, three=21)
> df
  one two three
1   1  11    21
> out <- apply(df, 2, \(x) x / 1)
> out
  one   two three 
    1    11    21 
> class(out)
[1] "numeric"
```

The solution I've implemented with this PR is to remove the call to `apply` entirely, and rely on matrix operations.

This also fixes an error when `n_samples_per_dimension = 1` and `user_provided_high_res_candidateset = FALSE`: `Error in if (colnames(M)[1] == \"(Intercept)\") {: argument is of length zero`.

# Test plan

I used this snippet to test the behaviour of `gen_momentsmatrix_constrained`:

```
design <- expand.grid(
    cat1=c('a', 'b', 'c'),
    num=1:3,
    cat2=c('x', 'y', 'z')
)

# Removes all but one combination of 'a' and 'x'
sub_design <- design[-c(1, 4),]

library(skpr)

for (n_samples in list(10, 1)) {
    for (high_res in list(FALSE, TRUE)) {
        for (df in list(design, sub_design)) {
            print('=========')
            print(paste("is_subset:", nrow(df) == nrow(sub_design)))
            print(paste("n_samples_per_dimension:", n_samples))
            print(paste("user_provided_high_res_candidateset:", high_res))
            tryCatch(
                {
                    print(
                        skpr:::gen_momentsmatrix_constrained(
                            df,
                            n_samples_per_dimension=n_samples,
                            user_provided_high_res_candidateset=high_res
                        )
                    )
                },
                error = function(e) {
                    print(paste("error: ", e))
                }
            )
        }
    }
}
```

With the fix in this PR applied, all combinations of input arguments give a return value.